### PR TITLE
feat: 支持强制删除 pod（强杀容器）

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ English | [简体中文](README_zh-CN.md)
 
 <h1 align="center">Mars</h1>
 <div align="center"><img style="width: 100px;height: 100px" src="./frontend/public/logo192.png" /></div>
-<p align="center">Built for DevOps. Deploy an application in 30 seconds.</p>
+<p align="center">You write the code, we ship it live. Production in 30 seconds.</p>
 <br><br>
 
 <div align="center">
@@ -15,7 +15,6 @@ English | [简体中文](README_zh-CN.md)
 [![unittest](https://github.com/duc-cnzj/mars/actions/workflows/test.yaml/badge.svg)](https://github.com/duc-cnzj/mars/actions/workflows/test.yaml)
 [![Release](https://img.shields.io/github/release/duc-cnzj/mars.svg)](https://github.com/duc-cnzj/mars/releases/latest)
 [![GitHub license](https://img.shields.io/github/license/duc-cnzj/mars)](https://github.com/duc-cnzj/mars/blob/master/LICENSE)
-[![Go Report Card](https://goreportcard.com/badge/github.com/duc-cnzj/mars/v6)](https://goreportcard.com/report/github.com/duc-cnzj/mars/v6)
 [![Documentation](https://pkg.go.dev/badge/github.com/duc-cnzj/mars/api/v6/grpc.svg)](https://pkg.go.dev/github.com/duc-cnzj/mars/api/v6/grpc)
 
 </div>

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -6,7 +6,7 @@
 
 <h1 align="center">Mars</h1>
 <div align="center"><img style="width: 100px;height: 100px" src="./frontend/public/logo192.png" /></div>
-<p align="center">专为devops而生，30秒内部署一个应用。</p>
+<p align="center">你负责代码，上线交给我。30 秒，生产环境见。</p>
 <br><br>
 
 <div align="center">
@@ -15,7 +15,6 @@
 [![unittest](https://github.com/duc-cnzj/mars/actions/workflows/test.yaml/badge.svg)](https://github.com/duc-cnzj/mars/actions/workflows/test.yaml)
 [![Release](https://img.shields.io/github/release/duc-cnzj/mars.svg)](https://github.com/duc-cnzj/mars/releases/latest)
 [![GitHub license](https://img.shields.io/github/license/duc-cnzj/mars)](https://github.com/duc-cnzj/mars/blob/master/LICENSE)
-[![Go Report Card](https://goreportcard.com/badge/github.com/duc-cnzj/mars/v6)](https://goreportcard.com/report/github.com/duc-cnzj/mars/v6)
 [![Documentation](https://pkg.go.dev/badge/github.com/duc-cnzj/mars/api/v6/grpc.svg)](https://pkg.go.dev/github.com/duc-cnzj/mars/api/v6/grpc)
 
 </div>

--- a/api/http/rest/container.gen.http.go
+++ b/api/http/rest/container.gen.http.go
@@ -59,3 +59,12 @@ func (s *ContainerSvc) ContainerLog(ctx context.Context, req *container.LogReque
 func (s *ContainerSvc) StreamContainerLog(ctx context.Context, req *container.LogRequest) (transport.Stream[*container.LogResponse], error) {
 	return transport.OpenStream[*container.LogResponse](s.C, ctx, http.MethodGet, fmt.Sprintf("/api/containers/namespaces/%s/pods/%s/containers/%s/stream_logs", url.PathEscape(req.Namespace), url.PathEscape(req.Pod), url.PathEscape(req.Container)), req)
 }
+
+// ForceDeletePod POST /api/containers/namespaces/{namespace}/pods/{pod}/force_delete。
+func (s *ContainerSvc) ForceDeletePod(ctx context.Context, req *container.ForceDeletePodRequest) (*container.ForceDeletePodResponse, error) {
+	var out container.ForceDeletePodResponse
+	if err := s.C.Do(ctx, http.MethodPost, fmt.Sprintf("/api/containers/namespaces/%s/pods/%s/force_delete", url.PathEscape(req.Namespace), url.PathEscape(req.Pod)), req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/api/proto/container/container.pb.go
+++ b/api/proto/container/container.pb.go
@@ -950,6 +950,135 @@ func (x *LogResponse) GetLog() string {
 	return ""
 }
 
+type ForceDeletePodRequest struct {
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Namespace string                 `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Pod       string                 `protobuf:"bytes,2,opt,name=pod,proto3" json:"pod,omitempty"`
+	// 优雅终止宽限期（秒）；0 表示立即强制删除，等价 kubectl delete --force。
+	GracePeriodSeconds int64 `protobuf:"varint,3,opt,name=grace_period_seconds,json=gracePeriodSeconds,proto3" json:"grace_period_seconds,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *ForceDeletePodRequest) Reset() {
+	*x = ForceDeletePodRequest{}
+	mi := &file_proto_container_container_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ForceDeletePodRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ForceDeletePodRequest) ProtoMessage() {}
+
+func (x *ForceDeletePodRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_container_container_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ForceDeletePodRequest.ProtoReflect.Descriptor instead.
+func (*ForceDeletePodRequest) Descriptor() ([]byte, []int) {
+	return file_proto_container_container_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *ForceDeletePodRequest) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *ForceDeletePodRequest) GetPod() string {
+	if x != nil {
+		return x.Pod
+	}
+	return ""
+}
+
+func (x *ForceDeletePodRequest) GetGracePeriodSeconds() int64 {
+	if x != nil {
+		return x.GracePeriodSeconds
+	}
+	return 0
+}
+
+type ForceDeletePodResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Deleted       bool                   `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	Namespace     string                 `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Pod           string                 `protobuf:"bytes,3,opt,name=pod,proto3" json:"pod,omitempty"`
+	Message       string                 `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ForceDeletePodResponse) Reset() {
+	*x = ForceDeletePodResponse{}
+	mi := &file_proto_container_container_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ForceDeletePodResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ForceDeletePodResponse) ProtoMessage() {}
+
+func (x *ForceDeletePodResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_container_container_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ForceDeletePodResponse.ProtoReflect.Descriptor instead.
+func (*ForceDeletePodResponse) Descriptor() ([]byte, []int) {
+	return file_proto_container_container_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *ForceDeletePodResponse) GetDeleted() bool {
+	if x != nil {
+		return x.Deleted
+	}
+	return false
+}
+
+func (x *ForceDeletePodResponse) GetNamespace() string {
+	if x != nil {
+		return x.Namespace
+	}
+	return ""
+}
+
+func (x *ForceDeletePodResponse) GetPod() string {
+	if x != nil {
+		return x.Pod
+	}
+	return ""
+}
+
+func (x *ForceDeletePodResponse) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
 var File_proto_container_container_proto protoreflect.FileDescriptor
 
 const file_proto_container_container_proto_rawDesc = "" +
@@ -1020,7 +1149,16 @@ const file_proto_container_container_proto_rawDesc = "" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12\x19\n" +
 	"\bpod_name\x18\x02 \x01(\tR\apodName\x12%\n" +
 	"\x0econtainer_name\x18\x03 \x01(\tR\rcontainerName\x12\x10\n" +
-	"\x03log\x18\x04 \x01(\tR\x03log2\x89\b\n" +
+	"\x03log\x18\x04 \x01(\tR\x03log\"\x93\x01\n" +
+	"\x15ForceDeletePodRequest\x12)\n" +
+	"\tnamespace\x18\x01 \x01(\tB\v\xe2A\x01\x02\xfaB\x04r\x02 \x01R\tnamespace\x12\x1d\n" +
+	"\x03pod\x18\x02 \x01(\tB\v\xe2A\x01\x02\xfaB\x04r\x02 \x01R\x03pod\x120\n" +
+	"\x14grace_period_seconds\x18\x03 \x01(\x03R\x12gracePeriodSeconds\"|\n" +
+	"\x16ForceDeletePodResponse\x12\x18\n" +
+	"\adeleted\x18\x01 \x01(\bR\adeleted\x12\x1c\n" +
+	"\tnamespace\x18\x02 \x01(\tR\tnamespace\x12\x10\n" +
+	"\x03pod\x18\x03 \x01(\tR\x03pod\x12\x18\n" +
+	"\amessage\x18\x04 \x01(\tR\amessage2\xc1\t\n" +
 	"\tContainer\x12\x86\x01\n" +
 	"\tCopyToPod\x12\x1b.container.CopyToPodRequest\x1a\x1c.container.CopyToPodResponse\">\xbaG\x15\x12\x13上传文件到 pod\x82\xd3\xe4\x93\x02 :\x01*\"\x1b/api/containers/copy_to_pod\x12;\n" +
 	"\x04Exec\x12\x16.container.ExecRequest\x1a\x17.container.ExecResponse(\x010\x01\x12A\n" +
@@ -1029,7 +1167,8 @@ const file_proto_container_container_proto_rawDesc = "" +
 	"\fIsPodRunning\x12\x1e.container.IsPodRunningRequest\x1a\x1f.container.IsPodRunningResponse\"D\xbaG\x14\x12\x12pod 是否 running\x82\xd3\xe4\x93\x02':\x01*\"\"/api/containers/pod_running_status\x12\x88\x01\n" +
 	"\vIsPodExists\x12\x1d.container.IsPodExistsRequest\x1a\x1e.container.IsPodExistsResponse\":\xbaG\x12\x12\x10pod 是否存在\x82\xd3\xe4\x93\x02\x1f:\x01*\"\x1a/api/containers/pod_exists\x12\xaa\x01\n" +
 	"\fContainerLog\x12\x15.container.LogRequest\x1a\x16.container.LogResponse\"k\xbaG\x13\x12\x11查看 pod 日志\x82\xd3\xe4\x93\x02O\x12M/api/containers/namespaces/{namespace}/pods/{pod}/containers/{container}/logs\x12\xc6\x01\n" +
-	"\x12StreamContainerLog\x12\x15.container.LogRequest\x1a\x16.container.LogResponse\"\x7f\xbaG \x12\x1estream 方式查看 pod 日志\x82\xd3\xe4\x93\x02V\x12T/api/containers/namespaces/{namespace}/pods/{pod}/containers/{container}/stream_logs0\x01B;Z9github.com/duc-cnzj/mars/api/v6/proto/container;containerb\x06proto3"
+	"\x12StreamContainerLog\x12\x15.container.LogRequest\x1a\x16.container.LogResponse\"\x7f\xbaG \x12\x1estream 方式查看 pod 日志\x82\xd3\xe4\x93\x02V\x12T/api/containers/namespaces/{namespace}/pods/{pod}/containers/{container}/stream_logs0\x01\x12\xb5\x01\n" +
+	"\x0eForceDeletePod\x12 .container.ForceDeletePodRequest\x1a!.container.ForceDeletePodResponse\"^\xbaG\x12\x12\x10强制删除 pod\x82\xd3\xe4\x93\x02C:\x01*\">/api/containers/namespaces/{namespace}/pods/{pod}/force_deleteB;Z9github.com/duc-cnzj/mars/api/v6/proto/container;containerb\x06proto3"
 
 var (
 	file_proto_container_container_proto_rawDescOnce sync.Once
@@ -1043,7 +1182,7 @@ func file_proto_container_container_proto_rawDescGZIP() []byte {
 	return file_proto_container_container_proto_rawDescData
 }
 
-var file_proto_container_container_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_proto_container_container_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_proto_container_container_proto_goTypes = []any{
 	(*CopyToPodRequest)(nil),        // 0: container.CopyToPodRequest
 	(*CopyToPodResponse)(nil),       // 1: container.CopyToPodResponse
@@ -1060,6 +1199,8 @@ var file_proto_container_container_proto_goTypes = []any{
 	(*IsPodExistsResponse)(nil),     // 12: container.IsPodExistsResponse
 	(*LogRequest)(nil),              // 13: container.LogRequest
 	(*LogResponse)(nil),             // 14: container.LogResponse
+	(*ForceDeletePodRequest)(nil),   // 15: container.ForceDeletePodRequest
+	(*ForceDeletePodResponse)(nil),  // 16: container.ForceDeletePodResponse
 }
 var file_proto_container_container_proto_depIdxs = []int32{
 	2,  // 0: container.ExecRequest.size_queue:type_name -> container.TerminalSize
@@ -1072,16 +1213,18 @@ var file_proto_container_container_proto_depIdxs = []int32{
 	11, // 7: container.Container.IsPodExists:input_type -> container.IsPodExistsRequest
 	13, // 8: container.Container.ContainerLog:input_type -> container.LogRequest
 	13, // 9: container.Container.StreamContainerLog:input_type -> container.LogRequest
-	1,  // 10: container.Container.CopyToPod:output_type -> container.CopyToPodResponse
-	6,  // 11: container.Container.Exec:output_type -> container.ExecResponse
-	6,  // 12: container.Container.ExecOnce:output_type -> container.ExecResponse
-	8,  // 13: container.Container.StreamCopyToPod:output_type -> container.StreamCopyToPodResponse
-	10, // 14: container.Container.IsPodRunning:output_type -> container.IsPodRunningResponse
-	12, // 15: container.Container.IsPodExists:output_type -> container.IsPodExistsResponse
-	14, // 16: container.Container.ContainerLog:output_type -> container.LogResponse
-	14, // 17: container.Container.StreamContainerLog:output_type -> container.LogResponse
-	10, // [10:18] is the sub-list for method output_type
-	2,  // [2:10] is the sub-list for method input_type
+	15, // 10: container.Container.ForceDeletePod:input_type -> container.ForceDeletePodRequest
+	1,  // 11: container.Container.CopyToPod:output_type -> container.CopyToPodResponse
+	6,  // 12: container.Container.Exec:output_type -> container.ExecResponse
+	6,  // 13: container.Container.ExecOnce:output_type -> container.ExecResponse
+	8,  // 14: container.Container.StreamCopyToPod:output_type -> container.StreamCopyToPodResponse
+	10, // 15: container.Container.IsPodRunning:output_type -> container.IsPodRunningResponse
+	12, // 16: container.Container.IsPodExists:output_type -> container.IsPodExistsResponse
+	14, // 17: container.Container.ContainerLog:output_type -> container.LogResponse
+	14, // 18: container.Container.StreamContainerLog:output_type -> container.LogResponse
+	16, // 19: container.Container.ForceDeletePod:output_type -> container.ForceDeletePodResponse
+	11, // [11:20] is the sub-list for method output_type
+	2,  // [2:11] is the sub-list for method input_type
 	2,  // [2:2] is the sub-list for extension type_name
 	2,  // [2:2] is the sub-list for extension extendee
 	0,  // [0:2] is the sub-list for field type_name
@@ -1098,7 +1241,7 @@ func file_proto_container_container_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_container_container_proto_rawDesc), len(file_proto_container_container_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   15,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/proto/container/container.pb.gw.go
+++ b/api/proto/container/container.pb.gw.go
@@ -392,6 +392,86 @@ func request_Container_StreamContainerLog_0(ctx context.Context, marshaler runti
 
 }
 
+func request_Container_ForceDeletePod_0(ctx context.Context, marshaler runtime.Marshaler, client ContainerClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ForceDeletePodRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["namespace"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "namespace")
+	}
+
+	protoReq.Namespace, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "namespace", err)
+	}
+
+	val, ok = pathParams["pod"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "pod")
+	}
+
+	protoReq.Pod, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "pod", err)
+	}
+
+	msg, err := client.ForceDeletePod(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Container_ForceDeletePod_0(ctx context.Context, marshaler runtime.Marshaler, server ContainerServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq ForceDeletePodRequest
+	var metadata runtime.ServerMetadata
+
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["namespace"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "namespace")
+	}
+
+	protoReq.Namespace, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "namespace", err)
+	}
+
+	val, ok = pathParams["pod"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "pod")
+	}
+
+	protoReq.Pod, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "pod", err)
+	}
+
+	msg, err := server.ForceDeletePod(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterContainerHandlerServer registers the http handlers for service Container to "mux".
 // UnaryRPC     :call ContainerServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -525,6 +605,31 @@ func RegisterContainerHandlerServer(ctx context.Context, mux *runtime.ServeMux, 
 		_, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 		return
+	})
+
+	mux.Handle("POST", pattern_Container_ForceDeletePod_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/container.Container/ForceDeletePod", runtime.WithHTTPPathPattern("/api/containers/namespaces/{namespace}/pods/{pod}/force_delete"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Container_ForceDeletePod_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Container_ForceDeletePod_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
 	})
 
 	return nil
@@ -744,6 +849,28 @@ func RegisterContainerHandlerClient(ctx context.Context, mux *runtime.ServeMux, 
 
 	})
 
+	mux.Handle("POST", pattern_Container_ForceDeletePod_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/container.Container/ForceDeletePod", runtime.WithHTTPPathPattern("/api/containers/namespaces/{namespace}/pods/{pod}/force_delete"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Container_ForceDeletePod_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Container_ForceDeletePod_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -763,6 +890,8 @@ var (
 	pattern_Container_ContainerLog_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4, 1, 0, 4, 1, 5, 5, 2, 1, 1, 0, 4, 1, 5, 6, 2, 7}, []string{"api", "containers", "namespaces", "namespace", "pods", "pod", "container", "logs"}, ""))
 
 	pattern_Container_StreamContainerLog_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4, 1, 0, 4, 1, 5, 5, 2, 1, 1, 0, 4, 1, 5, 6, 2, 7}, []string{"api", "containers", "namespaces", "namespace", "pods", "pod", "container", "stream_logs"}, ""))
+
+	pattern_Container_ForceDeletePod_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4, 1, 0, 4, 1, 5, 5, 2, 6}, []string{"api", "containers", "namespaces", "namespace", "pods", "pod", "force_delete"}, ""))
 )
 
 var (
@@ -781,4 +910,6 @@ var (
 	forward_Container_ContainerLog_0 = runtime.ForwardResponseMessage
 
 	forward_Container_StreamContainerLog_0 = runtime.ForwardResponseStream
+
+	forward_Container_ForceDeletePod_0 = runtime.ForwardResponseMessage
 )

--- a/api/proto/container/container.pb.validate.go
+++ b/api/proto/container/container.pb.validate.go
@@ -1877,3 +1877,239 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = LogResponseValidationError{}
+
+// Validate checks the field values on ForceDeletePodRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *ForceDeletePodRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on ForceDeletePodRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// ForceDeletePodRequestMultiError, or nil if none found.
+func (m *ForceDeletePodRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *ForceDeletePodRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if len(m.GetNamespace()) < 1 {
+		err := ForceDeletePodRequestValidationError{
+			field:  "Namespace",
+			reason: "value length must be at least 1 bytes",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
+	if len(m.GetPod()) < 1 {
+		err := ForceDeletePodRequestValidationError{
+			field:  "Pod",
+			reason: "value length must be at least 1 bytes",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
+	// no validation rules for GracePeriodSeconds
+
+	if len(errors) > 0 {
+		return ForceDeletePodRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// ForceDeletePodRequestMultiError is an error wrapping multiple validation
+// errors returned by ForceDeletePodRequest.ValidateAll() if the designated
+// constraints aren't met.
+type ForceDeletePodRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m ForceDeletePodRequestMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m ForceDeletePodRequestMultiError) AllErrors() []error { return m }
+
+// ForceDeletePodRequestValidationError is the validation error returned by
+// ForceDeletePodRequest.Validate if the designated constraints aren't met.
+type ForceDeletePodRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e ForceDeletePodRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e ForceDeletePodRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e ForceDeletePodRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e ForceDeletePodRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e ForceDeletePodRequestValidationError) ErrorName() string {
+	return "ForceDeletePodRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e ForceDeletePodRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sForceDeletePodRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = ForceDeletePodRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = ForceDeletePodRequestValidationError{}
+
+// Validate checks the field values on ForceDeletePodResponse with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *ForceDeletePodResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on ForceDeletePodResponse with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// ForceDeletePodResponseMultiError, or nil if none found.
+func (m *ForceDeletePodResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *ForceDeletePodResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for Deleted
+
+	// no validation rules for Namespace
+
+	// no validation rules for Pod
+
+	// no validation rules for Message
+
+	if len(errors) > 0 {
+		return ForceDeletePodResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// ForceDeletePodResponseMultiError is an error wrapping multiple validation
+// errors returned by ForceDeletePodResponse.ValidateAll() if the designated
+// constraints aren't met.
+type ForceDeletePodResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m ForceDeletePodResponseMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m ForceDeletePodResponseMultiError) AllErrors() []error { return m }
+
+// ForceDeletePodResponseValidationError is the validation error returned by
+// ForceDeletePodResponse.Validate if the designated constraints aren't met.
+type ForceDeletePodResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e ForceDeletePodResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e ForceDeletePodResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e ForceDeletePodResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e ForceDeletePodResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e ForceDeletePodResponseValidationError) ErrorName() string {
+	return "ForceDeletePodResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e ForceDeletePodResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sForceDeletePodResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = ForceDeletePodResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = ForceDeletePodResponseValidationError{}

--- a/api/proto/container/container.proto
+++ b/api/proto/container/container.proto
@@ -102,6 +102,20 @@ message LogResponse {
   string log            = 4;
 }
 
+message ForceDeletePodRequest {
+  string namespace = 1 [(validate.rules).string.min_bytes = 1, (google.api.field_behavior) = REQUIRED];
+  string pod       = 2 [(validate.rules).string.min_bytes = 1, (google.api.field_behavior) = REQUIRED];
+  // 优雅终止宽限期（秒）；0 表示立即强制删除，等价 kubectl delete --force。
+  int64  grace_period_seconds = 3;
+}
+
+message ForceDeletePodResponse {
+  bool   deleted   = 1;
+  string namespace = 2;
+  string pod       = 3;
+  string message   = 4;
+}
+
 service Container {
   rpc CopyToPod(CopyToPodRequest) returns (CopyToPodResponse) {
     option (google.api.http)      = {
@@ -161,6 +175,19 @@ service Container {
 
     option (openapi.v3.operation) = {
       summary: "stream 方式查看 pod 日志",
+    };
+  }
+
+  // ForceDeletePod 强制删除 pod：不等优雅终止直接移除（grace-period=0），
+  // 用于卡死/无法正常终止的 pod，等价 kubectl delete pod --force --grace-period=0。
+  rpc ForceDeletePod(ForceDeletePodRequest) returns (ForceDeletePodResponse) {
+    option (google.api.http)      = {
+      post: "/api/containers/namespaces/{namespace}/pods/{pod}/force_delete",
+      body: "*"
+    };
+
+    option (openapi.v3.operation) = {
+      summary: "强制删除 pod",
     };
   }
 }

--- a/api/proto/container/container_grpc.pb.go
+++ b/api/proto/container/container_grpc.pb.go
@@ -28,6 +28,7 @@ const (
 	Container_IsPodExists_FullMethodName        = "/container.Container/IsPodExists"
 	Container_ContainerLog_FullMethodName       = "/container.Container/ContainerLog"
 	Container_StreamContainerLog_FullMethodName = "/container.Container/StreamContainerLog"
+	Container_ForceDeletePod_FullMethodName     = "/container.Container/ForceDeletePod"
 )
 
 // ContainerClient is the client API for Container service.
@@ -46,6 +47,9 @@ type ContainerClient interface {
 	// ContainerLog 查看 pod 日志
 	ContainerLog(ctx context.Context, in *LogRequest, opts ...grpc.CallOption) (*LogResponse, error)
 	StreamContainerLog(ctx context.Context, in *LogRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[LogResponse], error)
+	// ForceDeletePod 强制删除 pod：不等优雅终止直接移除（grace-period=0），
+	// 用于卡死/无法正常终止的 pod，等价 kubectl delete pod --force --grace-period=0。
+	ForceDeletePod(ctx context.Context, in *ForceDeletePodRequest, opts ...grpc.CallOption) (*ForceDeletePodResponse, error)
 }
 
 type containerClient struct {
@@ -160,6 +164,16 @@ func (c *containerClient) StreamContainerLog(ctx context.Context, in *LogRequest
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Container_StreamContainerLogClient = grpc.ServerStreamingClient[LogResponse]
 
+func (c *containerClient) ForceDeletePod(ctx context.Context, in *ForceDeletePodRequest, opts ...grpc.CallOption) (*ForceDeletePodResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ForceDeletePodResponse)
+	err := c.cc.Invoke(ctx, Container_ForceDeletePod_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ContainerServer is the server API for Container service.
 // All implementations must embed UnimplementedContainerServer
 // for forward compatibility.
@@ -176,6 +190,9 @@ type ContainerServer interface {
 	// ContainerLog 查看 pod 日志
 	ContainerLog(context.Context, *LogRequest) (*LogResponse, error)
 	StreamContainerLog(*LogRequest, grpc.ServerStreamingServer[LogResponse]) error
+	// ForceDeletePod 强制删除 pod：不等优雅终止直接移除（grace-period=0），
+	// 用于卡死/无法正常终止的 pod，等价 kubectl delete pod --force --grace-period=0。
+	ForceDeletePod(context.Context, *ForceDeletePodRequest) (*ForceDeletePodResponse, error)
 	mustEmbedUnimplementedContainerServer()
 }
 
@@ -209,6 +226,9 @@ func (UnimplementedContainerServer) ContainerLog(context.Context, *LogRequest) (
 }
 func (UnimplementedContainerServer) StreamContainerLog(*LogRequest, grpc.ServerStreamingServer[LogResponse]) error {
 	return status.Error(codes.Unimplemented, "method StreamContainerLog not implemented")
+}
+func (UnimplementedContainerServer) ForceDeletePod(context.Context, *ForceDeletePodRequest) (*ForceDeletePodResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ForceDeletePod not implemented")
 }
 func (UnimplementedContainerServer) mustEmbedUnimplementedContainerServer() {}
 func (UnimplementedContainerServer) testEmbeddedByValue()                   {}
@@ -339,6 +359,24 @@ func _Container_StreamContainerLog_Handler(srv interface{}, stream grpc.ServerSt
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type Container_StreamContainerLogServer = grpc.ServerStreamingServer[LogResponse]
 
+func _Container_ForceDeletePod_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ForceDeletePodRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ContainerServer).ForceDeletePod(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Container_ForceDeletePod_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ContainerServer).ForceDeletePod(ctx, req.(*ForceDeletePodRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Container_ServiceDesc is the grpc.ServiceDesc for Container service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -361,6 +399,10 @@ var Container_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ContainerLog",
 			Handler:    _Container_ContainerLog_Handler,
+		},
+		{
+			MethodName: "ForceDeletePod",
+			Handler:    _Container_ForceDeletePod_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/api/proto/types/types.pb.go
+++ b/api/proto/types/types.pb.go
@@ -40,6 +40,8 @@ const (
 	EventActionType_CancelDeploy EventActionType = 9
 	// SDK 执行命令
 	EventActionType_Exec EventActionType = 10
+	// 强制删除 pod
+	EventActionType_ForceDeletePod EventActionType = 11
 )
 
 // Enum value maps for EventActionType.
@@ -56,19 +58,21 @@ var (
 		8:  "Login",
 		9:  "CancelDeploy",
 		10: "Exec",
+		11: "ForceDeletePod",
 	}
 	EventActionType_value = map[string]int32{
-		"Unknown":      0,
-		"Create":       1,
-		"Update":       2,
-		"Delete":       3,
-		"Upload":       4,
-		"Download":     5,
-		"DryRun":       6,
-		"Shell":        7,
-		"Login":        8,
-		"CancelDeploy": 9,
-		"Exec":         10,
+		"Unknown":        0,
+		"Create":         1,
+		"Update":         2,
+		"Delete":         3,
+		"Upload":         4,
+		"Download":       5,
+		"DryRun":         6,
+		"Shell":          7,
+		"Login":          8,
+		"CancelDeploy":   9,
+		"Exec":           10,
+		"ForceDeletePod": 11,
 	}
 )
 
@@ -1968,7 +1972,7 @@ const file_proto_types_types_proto_rawDesc = "" +
 	"\n" +
 	"updated_at\x18e \x01(\tR\tupdatedAt\x12\x1d\n" +
 	"\n" +
-	"deleted_at\x18f \x01(\tR\tdeletedAt*\x9a\x01\n" +
+	"deleted_at\x18f \x01(\tR\tdeletedAt*\xae\x01\n" +
 	"\x0fEventActionType\x12\v\n" +
 	"\aUnknown\x10\x00\x12\n" +
 	"\n" +
@@ -1986,7 +1990,8 @@ const file_proto_types_types_proto_rawDesc = "" +
 	"\x05Login\x10\b\x12\x10\n" +
 	"\fCancelDeploy\x10\t\x12\b\n" +
 	"\x04Exec\x10\n" +
-	"*V\n" +
+	"\x12\x12\n" +
+	"\x0eForceDeletePod\x10\v*V\n" +
 	"\x06Deploy\x12\x11\n" +
 	"\rStatusUnknown\x10\x00\x12\x13\n" +
 	"\x0fStatusDeploying\x10\x01\x12\x12\n" +

--- a/api/proto/types/types.proto
+++ b/api/proto/types/types.proto
@@ -21,6 +21,8 @@ enum EventActionType {
   CancelDeploy = 9;
   // SDK 执行命令
   Exec         = 10;
+  // 强制删除 pod
+  ForceDeletePod = 11;
 }
 
 

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -4,7 +4,7 @@
 openapi: 3.0.3
 info:
     title: mars api.
-    version: ""
+    version: api/v6.0.0-beta
 paths:
     /api/access_tokens:
         get:
@@ -355,6 +355,45 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/google.rpc.Status'
+    /api/containers/namespaces/{namespace}/pods/{pod}/force_delete:
+        post:
+            tags:
+                - Container
+            summary: 强制删除 pod
+            description: |-
+                ForceDeletePod 强制删除 pod：不等优雅终止直接移除（grace-period=0），
+                 用于卡死/无法正常终止的 pod，等价 kubectl delete pod --force --grace-period=0。
+            operationId: Container_ForceDeletePod
+            parameters:
+                - name: namespace
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                - name: pod
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/container.ForceDeletePodRequest'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/container.ForceDeletePodResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/google.rpc.Status'
     /api/containers/pod_exists:
         post:
             tags:
@@ -489,6 +528,7 @@ paths:
                         - Login
                         - CancelDeploy
                         - Exec
+                        - ForceDeletePod
                     type: string
                     format: enum
                 - name: search
@@ -1777,6 +1817,30 @@ components:
                     type: string
                 fileName:
                     type: string
+        container.ForceDeletePodRequest:
+            required:
+                - namespace
+                - pod
+            type: object
+            properties:
+                namespace:
+                    type: string
+                pod:
+                    type: string
+                gracePeriodSeconds:
+                    type: string
+                    description: 优雅终止宽限期（秒）；0 表示立即强制删除，等价 kubectl delete --force。
+        container.ForceDeletePodResponse:
+            type: object
+            properties:
+                deleted:
+                    type: boolean
+                namespace:
+                    type: string
+                pod:
+                    type: string
+                message:
+                    type: string
         container.IsPodExistsRequest:
             required:
                 - namespace
@@ -2604,6 +2668,7 @@ components:
                         - Login
                         - CancelDeploy
                         - Exec
+                        - ForceDeletePod
                     type: string
                     format: enum
                 username:

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -192,6 +192,27 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/containers/namespaces/{namespace}/pods/{pod}/force_delete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 强制删除 pod
+         * @description ForceDeletePod 强制删除 pod：不等优雅终止直接移除（grace-period=0），
+         *      用于卡死/无法正常终止的 pod，等价 kubectl delete pod --force --grace-period=0。
+         */
+        post: operations["Container_ForceDeletePod"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/containers/pod_exists": {
         parameters: {
             query?: never;
@@ -976,6 +997,18 @@ export interface components {
         "container.CopyToPodResponse": {
             podFilePath: string;
             fileName: string;
+        };
+        "container.ForceDeletePodRequest": {
+            namespace: string;
+            pod: string;
+            /** @description 优雅终止宽限期（秒）；0 表示立即强制删除，等价 kubectl delete --force。 */
+            gracePeriodSeconds?: string;
+        };
+        "container.ForceDeletePodResponse": {
+            deleted: boolean;
+            namespace: string;
+            pod: string;
+            message: string;
         };
         "container.IsPodExistsRequest": {
             namespace: string;
@@ -2000,6 +2033,42 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["container.LogResponse"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["google.rpc.Status"];
+                };
+            };
+        };
+    };
+    Container_ForceDeletePod: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                namespace: string;
+                pod: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["container.ForceDeletePodRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["container.ForceDeletePodResponse"];
                 };
             };
             /** @description Default error response */
@@ -3557,7 +3626,8 @@ export enum PathsApiEventsGetParametersQueryActionType {
     Shell = "Shell",
     Login = "Login",
     CancelDeploy = "CancelDeploy",
-    Exec = "Exec"
+    Exec = "Exec",
+    ForceDeletePod = "ForceDeletePod"
 }
 export enum MarsElementType {
     ElementTypeUnknown = "ElementTypeUnknown",
@@ -3581,7 +3651,8 @@ export enum TypesEventModelAction {
     Shell = "Shell",
     Login = "Login",
     CancelDeploy = "CancelDeploy",
-    Exec = "Exec"
+    Exec = "Exec",
+    ForceDeletePod = "ForceDeletePod"
 }
 export enum TypesProjectModelDeployStatus {
     StatusUnknown = "StatusUnknown",

--- a/frontend/src/components/TabShell.tsx
+++ b/frontend/src/components/TabShell.tsx
@@ -18,6 +18,7 @@ import {
   CloseOutlined,
   MinusOutlined,
   UploadOutlined,
+  PoweroffOutlined,
 } from "@ant-design/icons";
 import pb from "../api/websocket";
 import PodMetrics from "./PodMetrics";
@@ -97,6 +98,31 @@ const TabShell: React.FC<{
         }),
     [id],
   );
+
+  const forceDeletePod = useCallback(() => {
+    if (!value) {
+      return;
+    }
+    setForceDeleting(true);
+    ajax
+      .POST("/api/containers/namespaces/{namespace}/pods/{pod}/force_delete", {
+        params: { path: { namespace: value.namespace, pod: value.pod } },
+        body: {
+          namespace: value.namespace,
+          pod: value.pod,
+          gracePeriodSeconds: "0",
+        },
+      })
+      .then(({ data, error }) => {
+        setForceDeleting(false);
+        if (error) {
+          message.error(`强制删除 pod ${value.pod} 失败`);
+          return;
+        }
+        message.success(`pod ${value.pod} 已强制删除`, 2);
+        listContainer();
+      });
+  }, [value, listContainer]);
 
   const setValuesByResult = useCallback(
     (items: components["schemas"]["types.StateContainer"][]) => {
@@ -216,6 +242,7 @@ const TabShell: React.FC<{
 
   const [loading, setLoading] = useState(false);
   const [downloading, setDownloading] = useState(false);
+  const [forceDeleting, setForceDeleting] = useState(false);
 
   const props = {
     name: "file",
@@ -421,7 +448,7 @@ const TabShell: React.FC<{
                     style={{ fontSize: 12, marginRight: 2 }}
                     icon={<UploadOutlined />}
                   >
-                    {loading ? "上传中" : "上传到容器"}
+                    {loading ? "上传中" : "上传文件"}
                   </Button>
                 </Upload>
                 <Popconfirm
@@ -520,6 +547,32 @@ const TabShell: React.FC<{
                     onClick={() => addWebTerm("vertical")}
                   />
                 </div>
+                <Popconfirm
+                  title="强杀容器？"
+                  description={
+                    <span>
+                      将立即强制删除 pod「
+                      <span style={{ color: "red" }}>{value.pod}</span>
+                      」，跳过优雅终止，
+                      <span style={{ color: "red" }}>未持久化数据可能丢失</span>
+                      。
+                    </span>
+                  }
+                  okText="强杀容器"
+                  okButtonProps={{ danger: true }}
+                  cancelText="取消"
+                  onConfirm={forceDeletePod}
+                >
+                  <Button
+                    size="small"
+                    danger
+                    loading={forceDeleting}
+                    style={{ fontSize: 12, marginLeft: 2, marginRight: 2 }}
+                    icon={<PoweroffOutlined />}
+                  >
+                    强杀容器
+                  </Button>
+                </Popconfirm>
               </div>
               <PodMetrics
                 namespace={namespace}

--- a/frontend/src/pages/Events.tsx
+++ b/frontend/src/pages/Events.tsx
@@ -202,6 +202,12 @@ const EventList: React.FC = () => {
               删除
             </Tag>
           );
+        case TypesEventModelAction.ForceDeletePod:
+          return (
+            <Tag color="#a8071a" style={style}>
+              强杀容器
+            </Tag>
+          );
         case TypesEventModelAction.Upload:
           return (
             <Tag color="#fb7185" style={style}>
@@ -319,6 +325,9 @@ const EventList: React.FC = () => {
               <Option value={TypesEventModelAction.Login}>登录</Option>
               <Option value={TypesEventModelAction.CancelDeploy}>
                 取消部署
+              </Option>
+              <Option value={TypesEventModelAction.ForceDeletePod}>
+                强杀容器
               </Option>
             </Select>
             <Input

--- a/internal/biz/k8s.go
+++ b/internal/biz/k8s.go
@@ -11,6 +11,7 @@ import (
 	eventv1 "k8s.io/api/events/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -57,6 +58,10 @@ type K8sBiz interface {
 	DeleteSecret(ctx context.Context, namespace, secret string) error
 	// DeleteNamespace 校验名称后删除命名空间。
 	DeleteNamespace(ctx context.Context, name string) error
+	// ForceDeletePod 强制删除 pod：以指定宽限期与后台传播策略删除，
+	// gracePeriodSeconds=0 即不等优雅终止直接移除，等价 kubectl delete pod --force。
+	// 用于卡死/无法正常终止的 pod。
+	ForceDeletePod(ctx context.Context, namespace, pod string, gracePeriodSeconds int64) error
 	// GetAllPodMetrics 按项目 selectors 返回全部 pod 的指标列表。
 	GetAllPodMetrics(ctx context.Context, proj *Project) []v1beta1.PodMetrics
 	// CopyFileToPod 把文件拷贝进 pod 指定容器，返回落库的 File 记录。
@@ -182,6 +187,22 @@ func (k *k8sBiz) DeleteNamespace(ctx context.Context, name string) error {
 	return k.k8sRepo.DeleteNamespace(ctx, name)
 }
 
+// ForceDeletePod 强制删除 pod：空参或负宽限期返回 InvalidArgument，否则以
+// 指定宽限期 + PropagationPolicy=Background 透传 repo；gracePeriodSeconds=0 立即移除。
+func (k *k8sBiz) ForceDeletePod(ctx context.Context, namespace, pod string, gracePeriodSeconds int64) error {
+	if namespace == "" || pod == "" {
+		return errs.WrapInvalidArgument(errors.New("namespace 或 pod 名称不能为空"), "force delete pod")
+	}
+	if gracePeriodSeconds < 0 {
+		return errs.WrapInvalidArgument(errors.New("grace period seconds 不能为负数"), "force delete pod")
+	}
+	background := metav1.DeletePropagationBackground
+	return k.k8sRepo.DeletePod(ctx, namespace, pod, metav1.DeleteOptions{
+		GracePeriodSeconds: &gracePeriodSeconds,
+		PropagationPolicy:  &background,
+	})
+}
+
 // GetAllPodMetrics 按项目 PodSelectors 返回全部 pod 指标（透传 repo）。
 func (k *k8sBiz) GetAllPodMetrics(ctx context.Context, proj *Project) []v1beta1.PodMetrics {
 	return k.k8sRepo.GetAllPodMetrics(ctx, proj)
@@ -276,6 +297,8 @@ type K8sRepo interface {
 	DeleteSecret(ctx context.Context, namespace, secret string) error
 	// DeleteNamespace 删除命名空间。
 	DeleteNamespace(ctx context.Context, name string) error
+	// DeletePod 删除 pod，删除策略由 opts 决定（强制删除传 GracePeriodSeconds=0）。
+	DeletePod(ctx context.Context, namespace, pod string, opts metav1.DeleteOptions) error
 	// GetAllPodMetrics 返回项目全部 pod 的指标列表。
 	GetAllPodMetrics(ctx context.Context, proj *Project) []v1beta1.PodMetrics
 	// CopyFileToPod 把文件拷贝进 pod 指定容器。

--- a/internal/biz/k8s_test.go
+++ b/internal/biz/k8s_test.go
@@ -103,7 +103,8 @@ func TestGetPreOccupiedLenByValuesYaml(t *testing.T) {
 // fakeK8sRepoForK8sBiz 记录各写操作是否被调用，输入校验测试中 repo 不被调用（调用即 panic）。
 type fakeK8sRepoForK8sBiz struct {
 	K8sRepo
-	addTlsCalled, createNsCalled, deleteNsCalled, deleteSecretCalled bool
+	addTlsCalled, createNsCalled, deleteNsCalled, deleteSecretCalled, deletePodCalled bool
+	deletePodOpts                                                                     metav1.DeleteOptions
 }
 
 func (f *fakeK8sRepoForK8sBiz) AddTlsSecret(ns string, name string, key string, crt string) (*corev1.Secret, error) {
@@ -123,6 +124,12 @@ func (f *fakeK8sRepoForK8sBiz) DeleteSecret(ctx context.Context, namespace, secr
 
 func (f *fakeK8sRepoForK8sBiz) DeleteNamespace(ctx context.Context, name string) error {
 	f.deleteNsCalled = true
+	return nil
+}
+
+func (f *fakeK8sRepoForK8sBiz) DeletePod(ctx context.Context, namespace, pod string, opts metav1.DeleteOptions) error {
+	f.deletePodCalled = true
+	f.deletePodOpts = opts
 	return nil
 }
 
@@ -186,6 +193,36 @@ func TestK8sBiz_DeleteSecret_Valid(t *testing.T) {
 	b := NewK8sBiz(f)
 	assert.NoError(t, b.DeleteSecret(context.TODO(), "ns", "sec"))
 	assert.True(t, f.deleteSecretCalled)
+}
+
+func TestK8sBiz_ForceDeletePod_InvalidArgs(t *testing.T) {
+	k := NewK8sBiz(&fakeK8sRepoForK8sBiz{})
+	err := k.ForceDeletePod(context.TODO(), "", "pod", 0)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Equal(t, "namespace 或 pod 名称不能为空", status.Convert(err).Message())
+	err = k.ForceDeletePod(context.TODO(), "ns", "", 0)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	err = k.ForceDeletePod(context.TODO(), "ns", "pod", -1)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Equal(t, "grace period seconds 不能为负数", status.Convert(err).Message())
+}
+
+func TestK8sBiz_ForceDeletePod_Valid(t *testing.T) {
+	f := &fakeK8sRepoForK8sBiz{}
+	b := NewK8sBiz(f)
+	assert.NoError(t, b.ForceDeletePod(context.TODO(), "ns", "pod", 0))
+	assert.True(t, f.deletePodCalled)
+	// 透传强制删除策略：grace-period=0 + 后台传播
+	assert.Equal(t, int64(0), *f.deletePodOpts.GracePeriodSeconds)
+	assert.Equal(t, metav1.DeletePropagationBackground, *f.deletePodOpts.PropagationPolicy)
+}
+
+func TestK8sBiz_ForceDeletePod_ValidNonZeroGrace(t *testing.T) {
+	f := &fakeK8sRepoForK8sBiz{}
+	b := NewK8sBiz(f)
+	assert.NoError(t, b.ForceDeletePod(context.TODO(), "ns", "pod", 30))
+	assert.True(t, f.deletePodCalled)
+	assert.Equal(t, int64(30), *f.deletePodOpts.GracePeriodSeconds)
 }
 
 // fakeK8sRepoPassthrough 覆盖 k8sBiz 全部纯透传方法，记录调用并返回罐头数据。

--- a/internal/biz/mock_biz.go
+++ b/internal/biz/mock_biz.go
@@ -892,6 +892,20 @@ func (mr *MockK8sBizMockRecorder) FindDefaultContainer(arg0, arg1, arg2 any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindDefaultContainer", reflect.TypeOf((*MockK8sBiz)(nil).FindDefaultContainer), arg0, arg1, arg2)
 }
 
+// ForceDeletePod mocks base method.
+func (m *MockK8sBiz) ForceDeletePod(arg0 context.Context, arg1, arg2 string, arg3 int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForceDeletePod", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ForceDeletePod indicates an expected call of ForceDeletePod.
+func (mr *MockK8sBizMockRecorder) ForceDeletePod(arg0, arg1, arg2, arg3 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceDeletePod", reflect.TypeOf((*MockK8sBiz)(nil).ForceDeletePod), arg0, arg1, arg2, arg3)
+}
+
 // GetAllPodMetrics mocks base method.
 func (m *MockK8sBiz) GetAllPodMetrics(arg0 context.Context, arg1 *Project) []v1beta1.PodMetrics {
 	m.ctrl.T.Helper()

--- a/internal/data/k8s.go
+++ b/internal/data/k8s.go
@@ -293,6 +293,14 @@ func (repo *k8sRepo) DeleteSecret(ctx context.Context, namespace, secret string)
 	return errs.Wrap(repo.data.K8s().Client.CoreV1().Secrets(namespace).Delete(ctx, secret, metav1.DeleteOptions{}), "delete secret")
 }
 
+// DeletePod 删除命名空间下的 pod，删除策略由 opts 决定（如强制删除传
+// GracePeriodSeconds=0）。仅做 k8s API 级删除，不参与业务状态机。
+func (repo *k8sRepo) DeletePod(ctx context.Context, namespace, pod string, opts metav1.DeleteOptions) (err error) {
+	ctx, span := tracer.Start(ctx, "k8sRepo/DeletePod")
+	defer func() { endSpan(span, err) }()
+	return errs.Wrap(repo.data.K8s().Client.CoreV1().Pods(namespace).Delete(ctx, pod, opts), "delete pod")
+}
+
 // GetSecret 按命名空间与名称读取 secret。
 func (repo *k8sRepo) GetSecret(ctx context.Context, namespace, name string) (secret *corev1.Secret, err error) {
 	ctx, span := tracer.Start(ctx, "k8sRepo/GetSecret")

--- a/internal/data/k8s_test.go
+++ b/internal/data/k8s_test.go
@@ -1049,6 +1049,45 @@ func TestDeleteNamespace(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestDeletePod(t *testing.T) {
+	m := gomock.NewController(t)
+	defer m.Finish()
+	mockData := NewMockDataStore(m)
+	clientset := fake.NewSimpleClientset()
+	mockData.EXPECT().K8s().Return(&K8sClient{Client: clientset}).AnyTimes()
+	kr := &k8sRepo{
+		logger: mlog.NewForConfig(nil),
+		data:   mockData,
+	}
+	// 捕获实际下发的 DeleteOptions，验证 opts 透传（强制删除策略由 biz 层决定）
+	var gotOpts metav1.DeleteOptions
+	clientset.PrependReactor("delete", "pods", func(action testing2.Action) (bool, runtime.Object, error) {
+		if del, ok := action.(testing2.DeleteAction); ok {
+			gotOpts = del.GetDeleteOptions()
+		}
+		return false, nil, nil
+	})
+	// 删除不存在的 pod → errs.Wrap 归类为 NotFound
+	err := kr.DeletePod(context.TODO(), "a", "p", metav1.DeleteOptions{})
+	assert.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+	// 创建后强制删除 → 成功，GracePeriodSeconds/PropagationPolicy 透传
+	clientset.CoreV1().Pods("a").Create(context.TODO(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "a"},
+	}, metav1.CreateOptions{})
+	zero, bg := int64(0), metav1.DeletePropagationBackground
+	err = kr.DeletePod(context.TODO(), "a", "p", metav1.DeleteOptions{
+		GracePeriodSeconds: &zero,
+		PropagationPolicy:  &bg,
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(0), *gotOpts.GracePeriodSeconds)
+	assert.Equal(t, metav1.DeletePropagationBackground, *gotOpts.PropagationPolicy)
+	// 删除后 pod 已从 apiserver 移除
+	_, err = clientset.CoreV1().Pods("a").Get(context.TODO(), "p", metav1.GetOptions{})
+	assert.Error(t, err)
+}
+
 func TestDeleteSecret(t *testing.T) {
 	m := gomock.NewController(t)
 	defer m.Finish()

--- a/internal/data/mock_repo.go
+++ b/internal/data/mock_repo.go
@@ -28,8 +28,9 @@ import (
 	v11 "k8s.io/api/events/v1"
 	v12 "k8s.io/api/networking/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
+	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
-	v13 "sigs.k8s.io/gateway-api/apis/v1"
+	v14 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 // MockProjectRepo is a mock of ProjectRepo interface.
@@ -767,6 +768,20 @@ func (mr *MockK8sRepoMockRecorder) DeleteNamespace(arg0, arg1 any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespace", reflect.TypeOf((*MockK8sRepo)(nil).DeleteNamespace), arg0, arg1)
 }
 
+// DeletePod mocks base method.
+func (m *MockK8sRepo) DeletePod(arg0 context.Context, arg1, arg2 string, arg3 v13.DeleteOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeletePod", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeletePod indicates an expected call of DeletePod.
+func (mr *MockK8sRepoMockRecorder) DeletePod(arg0, arg1, arg2, arg3 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePod", reflect.TypeOf((*MockK8sRepo)(nil).DeletePod), arg0, arg1, arg2, arg3)
+}
+
 // DeleteSecret mocks base method.
 func (m *MockK8sRepo) DeleteSecret(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
@@ -1032,10 +1047,10 @@ func (mr *MockK8sRepoMockRecorder) ListEvents(arg0 any) *gomock.Call {
 }
 
 // ListHTTPRoutes mocks base method.
-func (m *MockK8sRepo) ListHTTPRoutes(arg0 string) ([]*v13.HTTPRoute, error) {
+func (m *MockK8sRepo) ListHTTPRoutes(arg0 string) ([]*v14.HTTPRoute, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListHTTPRoutes", arg0)
-	ret0, _ := ret[0].([]*v13.HTTPRoute)
+	ret0, _ := ret[0].([]*v14.HTTPRoute)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/plugins/wssender/redis/redis_pod_test.go
+++ b/internal/plugins/wssender/redis/redis_pod_test.go
@@ -113,8 +113,8 @@ func TestPodEventPublish(t *testing.T) {
 	channel := wssender.GetProjectPodEventRoom(7)
 
 	require.NoError(t, pem.pubSub.Subscribe(context.TODO(), channel))
-	// 同连接 PING 应答返回时 SUBSCRIBE 已在服务端生效，保证发布必达。
-	require.NoError(t, pem.pubSub.Ping(context.TODO()))
+	// go-redis Subscribe/Ping 都只写命令、不等服务端确认；显式读取确认应答确保订阅生效后发布必达。
+	assert.Equal(t, channel, mustReceiveSubscription(t, pem.pubSub).Channel)
 
 	require.NoError(t, pem.Publish(7, wssendertest.TestPod()))
 
@@ -236,8 +236,8 @@ func TestPodEventRun_dispatches(t *testing.T) {
 	nsID, pid := wssendertest.SeedProject(t, db, []string{"app=test"})
 	pem := newPEM(t, wssendertest.RedisAddr(t), db)
 	require.NoError(t, pem.Join(int64(pid)))
-	// Join 内部订阅是异步写命令；同连接 Ping 确认订阅生效后再发布，避免消息先于订阅丢失。
-	require.NoError(t, pem.pubSub.Ping(context.TODO()))
+	// Join 内部 Subscribe 是异步写命令；显式读取确认应答，确保服务端已登记频道订阅后再发布。
+	assert.Equal(t, wssender.GetProjectPodEventRoom(nsID), mustReceiveSubscription(t, pem.pubSub).Channel)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -262,8 +262,9 @@ func TestPodEventRun_skips_unsubscribed_channel(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	// 订阅一个 channelRefs 之外的频道：Run 应跳过该消息不 panic。
+	// 注意：Run 的 Channel() 已启动，此处不能用 Receive 消费确认（Receive* 与 Channel 互斥）；
+	// 无论消息先于/后于订阅到达，channelRefs 都不含 "extra"，测试结果均为"跳过"，无需同步。
 	require.NoError(t, pem.pubSub.Subscribe(context.TODO(), "extra"))
-	require.NoError(t, pem.pubSub.Ping(context.TODO()))
 	require.NoError(t, pem.rds.Publish(context.TODO(), "extra", `{"channel":"extra"}`).Err())
 	time.Sleep(100 * time.Millisecond)
 }
@@ -274,7 +275,7 @@ func TestPodEventRun_malformed_json(t *testing.T) {
 	pem := newPEM(t, wssendertest.RedisAddr(t), db)
 	channel := wssender.GetProjectPodEventRoom(nsID)
 	require.NoError(t, pem.Join(int64(pid)))
-	require.NoError(t, pem.pubSub.Ping(context.TODO()))
+	assert.Equal(t, wssender.GetProjectPodEventRoom(nsID), mustReceiveSubscription(t, pem.pubSub).Channel)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
@@ -291,7 +292,7 @@ func TestPodEventRun_nil_pod_skipped(t *testing.T) {
 	pem := newPEM(t, wssendertest.RedisAddr(t), db)
 	channel := wssender.GetProjectPodEventRoom(nsID)
 	require.NoError(t, pem.Join(int64(pid)))
-	require.NoError(t, pem.pubSub.Ping(context.TODO()))
+	assert.Equal(t, wssender.GetProjectPodEventRoom(nsID), mustReceiveSubscription(t, pem.pubSub).Channel)
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()

--- a/internal/plugins/wssender/redis/redis_test.go
+++ b/internal/plugins/wssender/redis/redis_test.go
@@ -25,6 +25,20 @@ const testRedisDB = 15
 // helpers
 // ---------------------------------------------------------------------------
 
+// mustReceiveSubscription 从 PubSub 读取一条应答并断言其为 Subscription 确认。
+// go-redis 的 Subscribe/Ping 都只写命令、不等服务端确认，此处显式消费确认应答，
+// 使"订阅已在服务端生效"这一时序假设可被证明，避免 Publish 先于订阅生效而丢消息。
+func mustReceiveSubscription(tb testing.TB, ps *redis.PubSub) *redis.Subscription {
+	tb.Helper()
+	ctx, cancel := context.WithTimeout(context.TODO(), 2*time.Second)
+	defer cancel()
+	reply, err := ps.Receive(ctx)
+	require.NoError(tb, err)
+	sub, ok := reply.(*redis.Subscription)
+	require.Truef(tb, ok, "expected *redis.Subscription, got %T", reply)
+	return sub
+}
+
 // newTestSender creates a redisSender connected to a real Redis (dedicated DB).
 // It flushes DB before use and cleans up on test completion. Redis 不可用时整体 t.Skip。
 func newTestSender(tb testing.TB) *redisSender {
@@ -42,9 +56,12 @@ func newTestSenderOn(tb testing.TB, addr string) *redisSender {
 
 	wsPubSub := rdb.Subscribe(context.TODO())
 	require.NoError(tb, wsPubSub.Subscribe(context.TODO(), wssender.BroadcastRoom))
-	// 同连接上 PING 应答返回时 SUBSCRIBE 已在服务端生效（Redis 按连接串行处理命令），
-	// 保证广播频道 setup 时订阅就已就绪，ToAll/ToOthers 首投即达。
-	require.NoError(tb, wsPubSub.Ping(context.TODO()))
+	// go-redis 的 PubSub.Subscribe 只写 SUBSCRIBE 命令、不等服务端确认（_subscribe 仅 writeCmd），
+	// PubSub.Ping 同样只写不读应答：二者都无法同步"订阅已生效"。Redis PubSub 无排队，
+	// 若 Publish 早于服务端处理 SUBSCRIBE 会直接丢消息（曾致 TestCrossInstanceToAll flake）。
+	// 故显式读取 Subscription 确认应答，确保广播频道订阅在服务端生效后 ToAll/ToOthers 首投即达。
+	sub := mustReceiveSubscription(tb, wsPubSub)
+	require.Equal(tb, wssender.BroadcastRoom, sub.Channel)
 
 	s := &redisSender{
 		rds:      rdb,

--- a/internal/services/container.go
+++ b/internal/services/container.go
@@ -315,6 +315,28 @@ func (c *containerSvc) ExecOnce(request *container.ExecOnceRequest, server conta
 	})
 }
 
+// ForceDeletePod 强制删除指定 pod：先做命名空间级访问控制，再以指定宽限期执行
+// 强制删除（gracePeriodSeconds=0 即不等优雅终止）。成功与失败均落审计日志
+// （EventActionType_ForceDeletePod），错误统一经 logError 打印。
+func (c *containerSvc) ForceDeletePod(ctx context.Context, request *container.ForceDeletePodRequest) (*container.ForceDeletePodResponse, error) {
+	if _, err := c.accessBiz.RequireNamespaceAccessByName(ctx, request.GetNamespace()); err != nil {
+		return nil, logError(ctx, c.logger, err)
+	}
+	user := biz.MustGetUser(ctx)
+	msg := fmt.Sprintf("强制删除 pod: %s/%s", request.GetNamespace(), request.GetPod())
+	if err := c.k8sBiz.ForceDeletePod(ctx, request.GetNamespace(), request.GetPod(), request.GetGracePeriodSeconds()); err != nil {
+		c.eventBiz.AuditLog(types.EventActionType_ForceDeletePod, user.Name, msg+", 失败: "+err.Error())
+		return nil, logError(ctx, c.logger, err)
+	}
+	c.eventBiz.AuditLog(types.EventActionType_ForceDeletePod, user.Name, msg)
+	return &container.ForceDeletePodResponse{
+		Deleted:   true,
+		Namespace: request.GetNamespace(),
+		Pod:       request.GetPod(),
+		Message:   fmt.Sprintf("pod %s/%s 已强制删除", request.GetNamespace(), request.GetPod()),
+	}, nil
+}
+
 // scannerText 按行切分文本并回调 fn；放大 Scanner 缓冲以容纳超长日志行。
 func scannerText(text string, fn func(s string)) error {
 	scanner := bufio.NewScanner(strings.NewReader(text))

--- a/internal/services/container_test.go
+++ b/internal/services/container_test.go
@@ -1515,6 +1515,45 @@ func Test_toValidUTF8String(t *testing.T) {
 	assert.Equal(t, "pure ascii text", toValidUTF8String(ascii))
 }
 
+func Test_containerSvc_ForceDeletePod_Success(t *testing.T) {
+	svc, mocks := newContainerSvcWithMocks(t)
+	mocks.nsRepo.EXPECT().FindByName(gomock.Any(), "a").Return(&biz.Namespace{}, nil).AnyTimes()
+	mocks.k8sRepo.EXPECT().DeletePod(gomock.Any(), "a", "b", gomock.Any()).Return(nil)
+	mocks.eventRepo.EXPECT().AuditLog(types.EventActionType_ForceDeletePod, "admin", gomock.Any()).Times(1)
+	resp, err := svc.ForceDeletePod(newAdminUserCtx(), &container.ForceDeletePodRequest{
+		Namespace: "a",
+		Pod:       "b",
+	})
+	assert.Nil(t, err)
+	assert.True(t, resp.Deleted)
+	assert.Equal(t, "a", resp.Namespace)
+	assert.Equal(t, "b", resp.Pod)
+	assert.Contains(t, resp.Message, "已强制删除")
+}
+
+func Test_containerSvc_ForceDeletePod_Error(t *testing.T) {
+	svc, mocks := newContainerSvcWithMocks(t)
+	mocks.nsRepo.EXPECT().FindByName(gomock.Any(), "a").Return(&biz.Namespace{}, nil).AnyTimes()
+	mocks.k8sRepo.EXPECT().DeletePod(gomock.Any(), "a", "b", gomock.Any()).Return(errors.New("k8s delete failed"))
+	mocks.eventRepo.EXPECT().AuditLog(types.EventActionType_ForceDeletePod, "admin", gomock.Any()).Times(1)
+	_, err := svc.ForceDeletePod(newAdminUserCtx(), &container.ForceDeletePodRequest{
+		Namespace: "a",
+		Pod:       "b",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "k8s delete failed")
+}
+
+func Test_containerSvc_ForceDeletePod_PermissionDenied(t *testing.T) {
+	svc, mocks := newContainerSvcWithMocks(t)
+	mocks.nsRepo.EXPECT().FindByName(gomock.Any(), "a").Return(&biz.Namespace{Private: true}, nil).AnyTimes()
+	_, err := svc.ForceDeletePod(newOtherUserCtx(), &container.ForceDeletePodRequest{
+		Namespace: "a",
+		Pod:       "b",
+	})
+	assert.ErrorIs(t, err, errs.ErrorPermissionDenied)
+}
+
 // containerSvcMocks 聚合 containerSvc 的全部下游 mock，由 newContainerSvcWithMocks 统一构造。
 type containerSvcMocks struct {
 	ctrl      *gomock.Controller


### PR DESCRIPTION
- proto 新增 ForceDeletePod RPC 与 ForceDeletePodRequest/Response，EventActionType 增加 ForceDeletePod=11
- biz/data/services 三层实现：biz 校验空参/负宽限期并透传 DeletePropagationBackground 策略，data 新增 k8sRepo.DeletePod，services 做命名空间级访问控制 + 审计日志
- 前端 TabShell 增加「强杀容器」危险操作按钮（Popconfirm 二次确认），Events 页增加强杀事件标签与过滤选项
- 补充 biz/data/services 单测并重生成 mock