### PR TITLE
feat: 新增 CheckApplyStatus 判定非原子部署后新版本容器状态

### DIFF
--- a/api/http/rest/project.gen.http.go
+++ b/api/http/rest/project.gen.http.go
@@ -80,3 +80,12 @@ func (s *ProjectSvc) AllContainers(ctx context.Context, req *project.AllContaine
 	}
 	return &out, nil
 }
+
+// CheckApplyStatus GET /api/projects/{id}/apply_status。
+func (s *ProjectSvc) CheckApplyStatus(ctx context.Context, req *project.CheckApplyStatusRequest) (*project.CheckApplyStatusResponse, error) {
+	var out project.CheckApplyStatusResponse
+	if err := s.C.DoQuery(ctx, http.MethodGet, fmt.Sprintf("/api/projects/%d/apply_status", req.Id), req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/api/proto/project/project.pb.go
+++ b/api/proto/project/project.pb.go
@@ -491,6 +491,216 @@ func (x *AllContainersResponse) GetItems() []*types.StateContainer {
 	return nil
 }
 
+// ContainerFailure 描述部署判定 FAILED 时失败容器的诊断信息（含日志尾部）。
+type ContainerFailure struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Kind          string                 `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"`           // 工作负载类型: Deployment/StatefulSet/DaemonSet
+	Workload      string                 `protobuf:"bytes,2,opt,name=workload,proto3" json:"workload,omitempty"`   // 工作负载名
+	Pod           string                 `protobuf:"bytes,3,opt,name=pod,proto3" json:"pod,omitempty"`             // 失败 pod 名
+	Container     string                 `protobuf:"bytes,4,opt,name=container,proto3" json:"container,omitempty"` // 失败容器名
+	Reason        string                 `protobuf:"bytes,5,opt,name=reason,proto3" json:"reason,omitempty"`       // 失败原因: CrashLoopBackOff/ImagePullBackOff/Error/OOMKilled/Evicted
+	Message       string                 `protobuf:"bytes,6,opt,name=message,proto3" json:"message,omitempty"`     // 容器状态 message（容器从未启动无日志时兜底展示）
+	Logs          string                 `protobuf:"bytes,7,opt,name=logs,proto3" json:"logs,omitempty"`           // 容器日志尾部（CrashLoopBackOff 取上一次崩溃日志）
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ContainerFailure) Reset() {
+	*x = ContainerFailure{}
+	mi := &file_proto_project_project_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ContainerFailure) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ContainerFailure) ProtoMessage() {}
+
+func (x *ContainerFailure) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_project_project_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ContainerFailure.ProtoReflect.Descriptor instead.
+func (*ContainerFailure) Descriptor() ([]byte, []int) {
+	return file_proto_project_project_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *ContainerFailure) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *ContainerFailure) GetWorkload() string {
+	if x != nil {
+		return x.Workload
+	}
+	return ""
+}
+
+func (x *ContainerFailure) GetPod() string {
+	if x != nil {
+		return x.Pod
+	}
+	return ""
+}
+
+func (x *ContainerFailure) GetContainer() string {
+	if x != nil {
+		return x.Container
+	}
+	return ""
+}
+
+func (x *ContainerFailure) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+func (x *ContainerFailure) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *ContainerFailure) GetLogs() string {
+	if x != nil {
+		return x.Logs
+	}
+	return ""
+}
+
+type CheckApplyStatusRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            int32                  `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CheckApplyStatusRequest) Reset() {
+	*x = CheckApplyStatusRequest{}
+	mi := &file_proto_project_project_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CheckApplyStatusRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CheckApplyStatusRequest) ProtoMessage() {}
+
+func (x *CheckApplyStatusRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_project_project_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CheckApplyStatusRequest.ProtoReflect.Descriptor instead.
+func (*CheckApplyStatusRequest) Descriptor() ([]byte, []int) {
+	return file_proto_project_project_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *CheckApplyStatusRequest) GetId() int32 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+type CheckApplyStatusResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// 聚合判定，复用 types.Deploy：StatusDeployed=正常 / StatusFailed=失败 /
+	// StatusDeploying=进行中 / StatusUnknown=未知（无工作负载或项目未部署）
+	Status types.Deploy `protobuf:"varint,1,opt,name=status,proto3,enum=types.Deploy" json:"status,omitempty"`
+	// 汇总原因（失败/进行中时的人类可读描述）
+	Reason string `protobuf:"bytes,2,opt,name=reason,proto3" json:"reason,omitempty"`
+	// 项目容器明细（含 is_old 新旧标记），前端可复用 AllContainers 的渲染
+	Containers []*types.StateContainer `protobuf:"bytes,3,rep,name=containers,proto3" json:"containers,omitempty"`
+	// 判定为 FAILED 时的具体失败容器列表
+	Failures      []*ContainerFailure `protobuf:"bytes,4,rep,name=failures,proto3" json:"failures,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CheckApplyStatusResponse) Reset() {
+	*x = CheckApplyStatusResponse{}
+	mi := &file_proto_project_project_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CheckApplyStatusResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CheckApplyStatusResponse) ProtoMessage() {}
+
+func (x *CheckApplyStatusResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_project_project_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CheckApplyStatusResponse.ProtoReflect.Descriptor instead.
+func (*CheckApplyStatusResponse) Descriptor() ([]byte, []int) {
+	return file_proto_project_project_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *CheckApplyStatusResponse) GetStatus() types.Deploy {
+	if x != nil {
+		return x.Status
+	}
+	return types.Deploy(0)
+}
+
+func (x *CheckApplyStatusResponse) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
+func (x *CheckApplyStatusResponse) GetContainers() []*types.StateContainer {
+	if x != nil {
+		return x.Containers
+	}
+	return nil
+}
+
+func (x *CheckApplyStatusResponse) GetFailures() []*ContainerFailure {
+	if x != nil {
+		return x.Failures
+	}
+	return nil
+}
+
 type ApplyResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Metadata      *websocket.Metadata    `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
@@ -501,7 +711,7 @@ type ApplyResponse struct {
 
 func (x *ApplyResponse) Reset() {
 	*x = ApplyResponse{}
-	mi := &file_proto_project_project_proto_msgTypes[10]
+	mi := &file_proto_project_project_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -513,7 +723,7 @@ func (x *ApplyResponse) String() string {
 func (*ApplyResponse) ProtoMessage() {}
 
 func (x *ApplyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_project_project_proto_msgTypes[10]
+	mi := &file_proto_project_project_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -526,7 +736,7 @@ func (x *ApplyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplyResponse.ProtoReflect.Descriptor instead.
 func (*ApplyResponse) Descriptor() ([]byte, []int) {
-	return file_proto_project_project_proto_rawDescGZIP(), []int{10}
+	return file_proto_project_project_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ApplyResponse) GetMetadata() *websocket.Metadata {
@@ -569,7 +779,7 @@ type ApplyRequest struct {
 
 func (x *ApplyRequest) Reset() {
 	*x = ApplyRequest{}
-	mi := &file_proto_project_project_proto_msgTypes[11]
+	mi := &file_proto_project_project_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -581,7 +791,7 @@ func (x *ApplyRequest) String() string {
 func (*ApplyRequest) ProtoMessage() {}
 
 func (x *ApplyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_project_project_proto_msgTypes[11]
+	mi := &file_proto_project_project_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -594,7 +804,7 @@ func (x *ApplyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplyRequest.ProtoReflect.Descriptor instead.
 func (*ApplyRequest) Descriptor() ([]byte, []int) {
-	return file_proto_project_project_proto_rawDescGZIP(), []int{11}
+	return file_proto_project_project_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ApplyRequest) GetNamespaceId() int32 {
@@ -700,7 +910,7 @@ type WebApplyRequest struct {
 
 func (x *WebApplyRequest) Reset() {
 	*x = WebApplyRequest{}
-	mi := &file_proto_project_project_proto_msgTypes[12]
+	mi := &file_proto_project_project_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -712,7 +922,7 @@ func (x *WebApplyRequest) String() string {
 func (*WebApplyRequest) ProtoMessage() {}
 
 func (x *WebApplyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_project_project_proto_msgTypes[12]
+	mi := &file_proto_project_project_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -725,7 +935,7 @@ func (x *WebApplyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WebApplyRequest.ProtoReflect.Descriptor instead.
 func (*WebApplyRequest) Descriptor() ([]byte, []int) {
-	return file_proto_project_project_proto_rawDescGZIP(), []int{12}
+	return file_proto_project_project_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *WebApplyRequest) GetNamespaceId() int32 {
@@ -802,7 +1012,7 @@ type WebApplyResponse struct {
 
 func (x *WebApplyResponse) Reset() {
 	*x = WebApplyResponse{}
-	mi := &file_proto_project_project_proto_msgTypes[13]
+	mi := &file_proto_project_project_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -814,7 +1024,7 @@ func (x *WebApplyResponse) String() string {
 func (*WebApplyResponse) ProtoMessage() {}
 
 func (x *WebApplyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_project_project_proto_msgTypes[13]
+	mi := &file_proto_project_project_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -827,7 +1037,7 @@ func (x *WebApplyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WebApplyResponse.ProtoReflect.Descriptor instead.
 func (*WebApplyResponse) Descriptor() ([]byte, []int) {
-	return file_proto_project_project_proto_rawDescGZIP(), []int{13}
+	return file_proto_project_project_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *WebApplyResponse) GetYamlFiles() []string {
@@ -860,7 +1070,7 @@ type MemoryCpuAndEndpointsRequest struct {
 
 func (x *MemoryCpuAndEndpointsRequest) Reset() {
 	*x = MemoryCpuAndEndpointsRequest{}
-	mi := &file_proto_project_project_proto_msgTypes[14]
+	mi := &file_proto_project_project_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -872,7 +1082,7 @@ func (x *MemoryCpuAndEndpointsRequest) String() string {
 func (*MemoryCpuAndEndpointsRequest) ProtoMessage() {}
 
 func (x *MemoryCpuAndEndpointsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_project_project_proto_msgTypes[14]
+	mi := &file_proto_project_project_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -885,7 +1095,7 @@ func (x *MemoryCpuAndEndpointsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MemoryCpuAndEndpointsRequest.ProtoReflect.Descriptor instead.
 func (*MemoryCpuAndEndpointsRequest) Descriptor() ([]byte, []int) {
-	return file_proto_project_project_proto_rawDescGZIP(), []int{14}
+	return file_proto_project_project_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *MemoryCpuAndEndpointsRequest) GetId() int32 {
@@ -906,7 +1116,7 @@ type MemoryCpuAndEndpointsResponse struct {
 
 func (x *MemoryCpuAndEndpointsResponse) Reset() {
 	*x = MemoryCpuAndEndpointsResponse{}
-	mi := &file_proto_project_project_proto_msgTypes[15]
+	mi := &file_proto_project_project_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -918,7 +1128,7 @@ func (x *MemoryCpuAndEndpointsResponse) String() string {
 func (*MemoryCpuAndEndpointsResponse) ProtoMessage() {}
 
 func (x *MemoryCpuAndEndpointsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_project_project_proto_msgTypes[15]
+	mi := &file_proto_project_project_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -931,7 +1141,7 @@ func (x *MemoryCpuAndEndpointsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MemoryCpuAndEndpointsResponse.ProtoReflect.Descriptor instead.
 func (*MemoryCpuAndEndpointsResponse) Descriptor() ([]byte, []int) {
-	return file_proto_project_project_proto_rawDescGZIP(), []int{15}
+	return file_proto_project_project_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *MemoryCpuAndEndpointsResponse) GetUrls() []*types.ServiceEndpoint {
@@ -985,7 +1195,24 @@ const file_proto_project_project_proto_rawDesc = "" +
 	"\x14AllContainersRequest\x12\x1b\n" +
 	"\x02id\x18\x01 \x01(\x05B\v\xe2A\x01\x02\xfaB\x04\x1a\x02 \x00R\x02id\"D\n" +
 	"\x15AllContainersResponse\x12+\n" +
-	"\x05items\x18\x01 \x03(\v2\x15.types.StateContainerR\x05items\"o\n" +
+	"\x05items\x18\x01 \x03(\v2\x15.types.StateContainerR\x05items\"\xb8\x01\n" +
+	"\x10ContainerFailure\x12\x12\n" +
+	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x1a\n" +
+	"\bworkload\x18\x02 \x01(\tR\bworkload\x12\x10\n" +
+	"\x03pod\x18\x03 \x01(\tR\x03pod\x12\x1c\n" +
+	"\tcontainer\x18\x04 \x01(\tR\tcontainer\x12\x16\n" +
+	"\x06reason\x18\x05 \x01(\tR\x06reason\x12\x18\n" +
+	"\amessage\x18\x06 \x01(\tR\amessage\x12\x12\n" +
+	"\x04logs\x18\a \x01(\tR\x04logs\"6\n" +
+	"\x17CheckApplyStatusRequest\x12\x1b\n" +
+	"\x02id\x18\x01 \x01(\x05B\v\xe2A\x01\x02\xfaB\x04\x1a\x02 \x00R\x02id\"\xc7\x01\n" +
+	"\x18CheckApplyStatusResponse\x12%\n" +
+	"\x06status\x18\x01 \x01(\x0e2\r.types.DeployR\x06status\x12\x16\n" +
+	"\x06reason\x18\x02 \x01(\tR\x06reason\x125\n" +
+	"\n" +
+	"containers\x18\x03 \x03(\v2\x15.types.StateContainerR\n" +
+	"containers\x125\n" +
+	"\bfailures\x18\x04 \x03(\v2\x19.project.ContainerFailureR\bfailures\"o\n" +
 	"\rApplyResponse\x12/\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x13.websocket.MetadataR\bmetadata\x12-\n" +
 	"\aproject\x18\x02 \x01(\v2\x13.types.ProjectModelR\aproject\"\xe7\x03\n" +
@@ -1031,7 +1258,7 @@ const file_proto_project_project_proto_rawDesc = "" +
 	"\x1dMemoryCpuAndEndpointsResponse\x12*\n" +
 	"\x04urls\x18\x01 \x03(\v2\x16.types.ServiceEndpointR\x04urls\x12\x10\n" +
 	"\x03cpu\x18\x02 \x01(\tR\x03cpu\x12\x16\n" +
-	"\x06memory\x18\x03 \x01(\tR\x06memory2\xec\x06\n" +
+	"\x06memory\x18\x03 \x01(\tR\x06memory2\x9e\b\n" +
 	"\aProject\x12J\n" +
 	"\x04List\x12\x14.project.ListRequest\x1a\x15.project.ListResponse\"\x15\x82\xd3\xe4\x93\x02\x0f\x12\r/api/projects\x128\n" +
 	"\x05Apply\x12\x15.project.ApplyRequest\x1a\x16.project.ApplyResponse0\x01\x12\x88\x01\n" +
@@ -1040,7 +1267,8 @@ const file_proto_project_project_proto_rawDesc = "" +
 	"\x15MemoryCpuAndEndpoints\x12%.project.MemoryCpuAndEndpointsRequest\x1a&.project.MemoryCpuAndEndpointsResponse\"U\xbaG\x1f\x12\x1d项目的cpu/memory/endpoints\x82\xd3\xe4\x93\x02-\x12+/api/projects/{id}/memory_cpu_and_endpoints\x12`\n" +
 	"\aVersion\x12\x17.project.VersionRequest\x1a\x18.project.VersionResponse\"\"\x82\xd3\xe4\x93\x02\x1c\x12\x1a/api/projects/{id}/version\x12U\n" +
 	"\x06Delete\x12\x16.project.DeleteRequest\x1a\x17.project.DeleteResponse\"\x1a\x82\xd3\xe4\x93\x02\x14*\x12/api/projects/{id}\x12u\n" +
-	"\rAllContainers\x12\x1d.project.AllContainersRequest\x1a\x1e.project.AllContainersResponse\"%\x82\xd3\xe4\x93\x02\x1f\x12\x1d/api/projects/{id}/containersB7Z5github.com/duc-cnzj/mars/api/v6/proto/project;projectb\x06proto3"
+	"\rAllContainers\x12\x1d.project.AllContainersRequest\x1a\x1e.project.AllContainersResponse\"%\x82\xd3\xe4\x93\x02\x1f\x12\x1d/api/projects/{id}/containers\x12\xaf\x01\n" +
+	"\x10CheckApplyStatus\x12 .project.CheckApplyStatusRequest\x1a!.project.CheckApplyStatusResponse\"V\xbaG,\x12*检查项目部署后的容器运行状态\x82\xd3\xe4\x93\x02!\x12\x1f/api/projects/{id}/apply_statusB7Z5github.com/duc-cnzj/mars/api/v6/proto/project;projectb\x06proto3"
 
 var (
 	file_proto_project_project_proto_rawDescOnce sync.Once
@@ -1054,7 +1282,7 @@ func file_proto_project_project_proto_rawDescGZIP() []byte {
 	return file_proto_project_project_proto_rawDescData
 }
 
-var file_proto_project_project_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
+var file_proto_project_project_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
 var file_proto_project_project_proto_goTypes = []any{
 	(*ListRequest)(nil),                   // 0: project.ListRequest
 	(*ListResponse)(nil),                  // 1: project.ListResponse
@@ -1066,49 +1294,58 @@ var file_proto_project_project_proto_goTypes = []any{
 	(*VersionResponse)(nil),               // 7: project.VersionResponse
 	(*AllContainersRequest)(nil),          // 8: project.AllContainersRequest
 	(*AllContainersResponse)(nil),         // 9: project.AllContainersResponse
-	(*ApplyResponse)(nil),                 // 10: project.ApplyResponse
-	(*ApplyRequest)(nil),                  // 11: project.ApplyRequest
-	(*WebApplyRequest)(nil),               // 12: project.WebApplyRequest
-	(*WebApplyResponse)(nil),              // 13: project.WebApplyResponse
-	(*MemoryCpuAndEndpointsRequest)(nil),  // 14: project.MemoryCpuAndEndpointsRequest
-	(*MemoryCpuAndEndpointsResponse)(nil), // 15: project.MemoryCpuAndEndpointsResponse
-	(*types.ProjectModel)(nil),            // 16: types.ProjectModel
-	(*types.StateContainer)(nil),          // 17: types.StateContainer
-	(*websocket.Metadata)(nil),            // 18: websocket.Metadata
-	(*websocket.ExtraValue)(nil),          // 19: websocket.ExtraValue
-	(*types.ServiceEndpoint)(nil),         // 20: types.ServiceEndpoint
+	(*ContainerFailure)(nil),              // 10: project.ContainerFailure
+	(*CheckApplyStatusRequest)(nil),       // 11: project.CheckApplyStatusRequest
+	(*CheckApplyStatusResponse)(nil),      // 12: project.CheckApplyStatusResponse
+	(*ApplyResponse)(nil),                 // 13: project.ApplyResponse
+	(*ApplyRequest)(nil),                  // 14: project.ApplyRequest
+	(*WebApplyRequest)(nil),               // 15: project.WebApplyRequest
+	(*WebApplyResponse)(nil),              // 16: project.WebApplyResponse
+	(*MemoryCpuAndEndpointsRequest)(nil),  // 17: project.MemoryCpuAndEndpointsRequest
+	(*MemoryCpuAndEndpointsResponse)(nil), // 18: project.MemoryCpuAndEndpointsResponse
+	(*types.ProjectModel)(nil),            // 19: types.ProjectModel
+	(*types.StateContainer)(nil),          // 20: types.StateContainer
+	(types.Deploy)(0),                     // 21: types.Deploy
+	(*websocket.Metadata)(nil),            // 22: websocket.Metadata
+	(*websocket.ExtraValue)(nil),          // 23: websocket.ExtraValue
+	(*types.ServiceEndpoint)(nil),         // 24: types.ServiceEndpoint
 }
 var file_proto_project_project_proto_depIdxs = []int32{
-	16, // 0: project.ListResponse.items:type_name -> types.ProjectModel
-	16, // 1: project.ShowResponse.item:type_name -> types.ProjectModel
-	17, // 2: project.AllContainersResponse.items:type_name -> types.StateContainer
-	18, // 3: project.ApplyResponse.metadata:type_name -> websocket.Metadata
-	16, // 4: project.ApplyResponse.project:type_name -> types.ProjectModel
-	19, // 5: project.ApplyRequest.extra_values:type_name -> websocket.ExtraValue
-	19, // 6: project.WebApplyRequest.extra_values:type_name -> websocket.ExtraValue
-	16, // 7: project.WebApplyResponse.project:type_name -> types.ProjectModel
-	20, // 8: project.MemoryCpuAndEndpointsResponse.urls:type_name -> types.ServiceEndpoint
-	0,  // 9: project.Project.List:input_type -> project.ListRequest
-	11, // 10: project.Project.Apply:input_type -> project.ApplyRequest
-	12, // 11: project.Project.WebApply:input_type -> project.WebApplyRequest
-	2,  // 12: project.Project.Show:input_type -> project.ShowRequest
-	14, // 13: project.Project.MemoryCpuAndEndpoints:input_type -> project.MemoryCpuAndEndpointsRequest
-	6,  // 14: project.Project.Version:input_type -> project.VersionRequest
-	4,  // 15: project.Project.Delete:input_type -> project.DeleteRequest
-	8,  // 16: project.Project.AllContainers:input_type -> project.AllContainersRequest
-	1,  // 17: project.Project.List:output_type -> project.ListResponse
-	10, // 18: project.Project.Apply:output_type -> project.ApplyResponse
-	13, // 19: project.Project.WebApply:output_type -> project.WebApplyResponse
-	3,  // 20: project.Project.Show:output_type -> project.ShowResponse
-	15, // 21: project.Project.MemoryCpuAndEndpoints:output_type -> project.MemoryCpuAndEndpointsResponse
-	7,  // 22: project.Project.Version:output_type -> project.VersionResponse
-	5,  // 23: project.Project.Delete:output_type -> project.DeleteResponse
-	9,  // 24: project.Project.AllContainers:output_type -> project.AllContainersResponse
-	17, // [17:25] is the sub-list for method output_type
-	9,  // [9:17] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	19, // 0: project.ListResponse.items:type_name -> types.ProjectModel
+	19, // 1: project.ShowResponse.item:type_name -> types.ProjectModel
+	20, // 2: project.AllContainersResponse.items:type_name -> types.StateContainer
+	21, // 3: project.CheckApplyStatusResponse.status:type_name -> types.Deploy
+	20, // 4: project.CheckApplyStatusResponse.containers:type_name -> types.StateContainer
+	10, // 5: project.CheckApplyStatusResponse.failures:type_name -> project.ContainerFailure
+	22, // 6: project.ApplyResponse.metadata:type_name -> websocket.Metadata
+	19, // 7: project.ApplyResponse.project:type_name -> types.ProjectModel
+	23, // 8: project.ApplyRequest.extra_values:type_name -> websocket.ExtraValue
+	23, // 9: project.WebApplyRequest.extra_values:type_name -> websocket.ExtraValue
+	19, // 10: project.WebApplyResponse.project:type_name -> types.ProjectModel
+	24, // 11: project.MemoryCpuAndEndpointsResponse.urls:type_name -> types.ServiceEndpoint
+	0,  // 12: project.Project.List:input_type -> project.ListRequest
+	14, // 13: project.Project.Apply:input_type -> project.ApplyRequest
+	15, // 14: project.Project.WebApply:input_type -> project.WebApplyRequest
+	2,  // 15: project.Project.Show:input_type -> project.ShowRequest
+	17, // 16: project.Project.MemoryCpuAndEndpoints:input_type -> project.MemoryCpuAndEndpointsRequest
+	6,  // 17: project.Project.Version:input_type -> project.VersionRequest
+	4,  // 18: project.Project.Delete:input_type -> project.DeleteRequest
+	8,  // 19: project.Project.AllContainers:input_type -> project.AllContainersRequest
+	11, // 20: project.Project.CheckApplyStatus:input_type -> project.CheckApplyStatusRequest
+	1,  // 21: project.Project.List:output_type -> project.ListResponse
+	13, // 22: project.Project.Apply:output_type -> project.ApplyResponse
+	16, // 23: project.Project.WebApply:output_type -> project.WebApplyResponse
+	3,  // 24: project.Project.Show:output_type -> project.ShowResponse
+	18, // 25: project.Project.MemoryCpuAndEndpoints:output_type -> project.MemoryCpuAndEndpointsResponse
+	7,  // 26: project.Project.Version:output_type -> project.VersionResponse
+	5,  // 27: project.Project.Delete:output_type -> project.DeleteResponse
+	9,  // 28: project.Project.AllContainers:output_type -> project.AllContainersResponse
+	12, // 29: project.Project.CheckApplyStatus:output_type -> project.CheckApplyStatusResponse
+	21, // [21:30] is the sub-list for method output_type
+	12, // [12:21] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_proto_project_project_proto_init() }
@@ -1117,15 +1354,15 @@ func file_proto_project_project_proto_init() {
 		return
 	}
 	file_proto_project_project_proto_msgTypes[0].OneofWrappers = []any{}
-	file_proto_project_project_proto_msgTypes[11].OneofWrappers = []any{}
-	file_proto_project_project_proto_msgTypes[12].OneofWrappers = []any{}
+	file_proto_project_project_proto_msgTypes[14].OneofWrappers = []any{}
+	file_proto_project_project_proto_msgTypes[15].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_proto_project_project_proto_rawDesc), len(file_proto_project_project_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   16,
+			NumMessages:   19,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/proto/project/project.pb.gw.go
+++ b/api/proto/project/project.pb.gw.go
@@ -374,6 +374,58 @@ func local_request_Project_AllContainers_0(ctx context.Context, marshaler runtim
 
 }
 
+func request_Project_CheckApplyStatus_0(ctx context.Context, marshaler runtime.Marshaler, client ProjectClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq CheckApplyStatusRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.Int32(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := client.CheckApplyStatus(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Project_CheckApplyStatus_0(ctx context.Context, marshaler runtime.Marshaler, server ProjectServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq CheckApplyStatusRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "id")
+	}
+
+	protoReq.Id, err = runtime.Int32(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "id", err)
+	}
+
+	msg, err := server.CheckApplyStatus(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 // RegisterProjectHandlerServer registers the http handlers for service Project to "mux".
 // UnaryRPC     :call ProjectServer directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -560,6 +612,31 @@ func RegisterProjectHandlerServer(ctx context.Context, mux *runtime.ServeMux, se
 		}
 
 		forward_Project_AllContainers_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
+	mux.Handle("GET", pattern_Project_CheckApplyStatus_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/project.Project/CheckApplyStatus", runtime.WithHTTPPathPattern("/api/projects/{id}/apply_status"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Project_CheckApplyStatus_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Project_CheckApplyStatus_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -780,6 +857,28 @@ func RegisterProjectHandlerClient(ctx context.Context, mux *runtime.ServeMux, cl
 
 	})
 
+	mux.Handle("GET", pattern_Project_CheckApplyStatus_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		var err error
+		var annotatedContext context.Context
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/project.Project/CheckApplyStatus", runtime.WithHTTPPathPattern("/api/projects/{id}/apply_status"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Project_CheckApplyStatus_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Project_CheckApplyStatus_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	return nil
 }
 
@@ -799,6 +898,8 @@ var (
 	pattern_Project_Delete_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"api", "projects", "id"}, ""))
 
 	pattern_Project_AllContainers_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"api", "projects", "id", "containers"}, ""))
+
+	pattern_Project_CheckApplyStatus_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2, 2, 3}, []string{"api", "projects", "id", "apply_status"}, ""))
 )
 
 var (
@@ -817,4 +918,6 @@ var (
 	forward_Project_Delete_0 = runtime.ForwardResponseMessage
 
 	forward_Project_AllContainers_0 = runtime.ForwardResponseMessage
+
+	forward_Project_CheckApplyStatus_0 = runtime.ForwardResponseMessage
 )

--- a/api/proto/project/project.pb.validate.go
+++ b/api/proto/project/project.pb.validate.go
@@ -17,6 +17,8 @@ import (
 	"unicode/utf8"
 
 	"google.golang.org/protobuf/types/known/anypb"
+
+	types "github.com/duc-cnzj/mars/api/v6/proto/types"
 )
 
 // ensure the imports are used
@@ -33,6 +35,8 @@ var (
 	_ = (*mail.Address)(nil)
 	_ = anypb.Any{}
 	_ = sort.Sort
+
+	_ = types.Deploy(0)
 )
 
 // Validate checks the field values on ListRequest with the rules defined in
@@ -1191,6 +1195,407 @@ var _ interface {
 	Cause() error
 	ErrorName() string
 } = AllContainersResponseValidationError{}
+
+// Validate checks the field values on ContainerFailure with the rules defined
+// in the proto definition for this message. If any rules are violated, the
+// first error encountered is returned, or nil if there are no violations.
+func (m *ContainerFailure) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on ContainerFailure with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// ContainerFailureMultiError, or nil if none found.
+func (m *ContainerFailure) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *ContainerFailure) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for Kind
+
+	// no validation rules for Workload
+
+	// no validation rules for Pod
+
+	// no validation rules for Container
+
+	// no validation rules for Reason
+
+	// no validation rules for Message
+
+	// no validation rules for Logs
+
+	if len(errors) > 0 {
+		return ContainerFailureMultiError(errors)
+	}
+
+	return nil
+}
+
+// ContainerFailureMultiError is an error wrapping multiple validation errors
+// returned by ContainerFailure.ValidateAll() if the designated constraints
+// aren't met.
+type ContainerFailureMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m ContainerFailureMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m ContainerFailureMultiError) AllErrors() []error { return m }
+
+// ContainerFailureValidationError is the validation error returned by
+// ContainerFailure.Validate if the designated constraints aren't met.
+type ContainerFailureValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e ContainerFailureValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e ContainerFailureValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e ContainerFailureValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e ContainerFailureValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e ContainerFailureValidationError) ErrorName() string { return "ContainerFailureValidationError" }
+
+// Error satisfies the builtin error interface
+func (e ContainerFailureValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sContainerFailure.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = ContainerFailureValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = ContainerFailureValidationError{}
+
+// Validate checks the field values on CheckApplyStatusRequest with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *CheckApplyStatusRequest) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on CheckApplyStatusRequest with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// CheckApplyStatusRequestMultiError, or nil if none found.
+func (m *CheckApplyStatusRequest) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *CheckApplyStatusRequest) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	if m.GetId() <= 0 {
+		err := CheckApplyStatusRequestValidationError{
+			field:  "Id",
+			reason: "value must be greater than 0",
+		}
+		if !all {
+			return err
+		}
+		errors = append(errors, err)
+	}
+
+	if len(errors) > 0 {
+		return CheckApplyStatusRequestMultiError(errors)
+	}
+
+	return nil
+}
+
+// CheckApplyStatusRequestMultiError is an error wrapping multiple validation
+// errors returned by CheckApplyStatusRequest.ValidateAll() if the designated
+// constraints aren't met.
+type CheckApplyStatusRequestMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m CheckApplyStatusRequestMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m CheckApplyStatusRequestMultiError) AllErrors() []error { return m }
+
+// CheckApplyStatusRequestValidationError is the validation error returned by
+// CheckApplyStatusRequest.Validate if the designated constraints aren't met.
+type CheckApplyStatusRequestValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e CheckApplyStatusRequestValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e CheckApplyStatusRequestValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e CheckApplyStatusRequestValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e CheckApplyStatusRequestValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e CheckApplyStatusRequestValidationError) ErrorName() string {
+	return "CheckApplyStatusRequestValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e CheckApplyStatusRequestValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sCheckApplyStatusRequest.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = CheckApplyStatusRequestValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = CheckApplyStatusRequestValidationError{}
+
+// Validate checks the field values on CheckApplyStatusResponse with the rules
+// defined in the proto definition for this message. If any rules are
+// violated, the first error encountered is returned, or nil if there are no violations.
+func (m *CheckApplyStatusResponse) Validate() error {
+	return m.validate(false)
+}
+
+// ValidateAll checks the field values on CheckApplyStatusResponse with the
+// rules defined in the proto definition for this message. If any rules are
+// violated, the result is a list of violation errors wrapped in
+// CheckApplyStatusResponseMultiError, or nil if none found.
+func (m *CheckApplyStatusResponse) ValidateAll() error {
+	return m.validate(true)
+}
+
+func (m *CheckApplyStatusResponse) validate(all bool) error {
+	if m == nil {
+		return nil
+	}
+
+	var errors []error
+
+	// no validation rules for Status
+
+	// no validation rules for Reason
+
+	for idx, item := range m.GetContainers() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, CheckApplyStatusResponseValidationError{
+						field:  fmt.Sprintf("Containers[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, CheckApplyStatusResponseValidationError{
+						field:  fmt.Sprintf("Containers[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return CheckApplyStatusResponseValidationError{
+					field:  fmt.Sprintf("Containers[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	for idx, item := range m.GetFailures() {
+		_, _ = idx, item
+
+		if all {
+			switch v := interface{}(item).(type) {
+			case interface{ ValidateAll() error }:
+				if err := v.ValidateAll(); err != nil {
+					errors = append(errors, CheckApplyStatusResponseValidationError{
+						field:  fmt.Sprintf("Failures[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			case interface{ Validate() error }:
+				if err := v.Validate(); err != nil {
+					errors = append(errors, CheckApplyStatusResponseValidationError{
+						field:  fmt.Sprintf("Failures[%v]", idx),
+						reason: "embedded message failed validation",
+						cause:  err,
+					})
+				}
+			}
+		} else if v, ok := interface{}(item).(interface{ Validate() error }); ok {
+			if err := v.Validate(); err != nil {
+				return CheckApplyStatusResponseValidationError{
+					field:  fmt.Sprintf("Failures[%v]", idx),
+					reason: "embedded message failed validation",
+					cause:  err,
+				}
+			}
+		}
+
+	}
+
+	if len(errors) > 0 {
+		return CheckApplyStatusResponseMultiError(errors)
+	}
+
+	return nil
+}
+
+// CheckApplyStatusResponseMultiError is an error wrapping multiple validation
+// errors returned by CheckApplyStatusResponse.ValidateAll() if the designated
+// constraints aren't met.
+type CheckApplyStatusResponseMultiError []error
+
+// Error returns a concatenation of all the error messages it wraps.
+func (m CheckApplyStatusResponseMultiError) Error() string {
+	var msgs []string
+	for _, err := range m {
+		msgs = append(msgs, err.Error())
+	}
+	return strings.Join(msgs, "; ")
+}
+
+// AllErrors returns a list of validation violation errors.
+func (m CheckApplyStatusResponseMultiError) AllErrors() []error { return m }
+
+// CheckApplyStatusResponseValidationError is the validation error returned by
+// CheckApplyStatusResponse.Validate if the designated constraints aren't met.
+type CheckApplyStatusResponseValidationError struct {
+	field  string
+	reason string
+	cause  error
+	key    bool
+}
+
+// Field function returns field value.
+func (e CheckApplyStatusResponseValidationError) Field() string { return e.field }
+
+// Reason function returns reason value.
+func (e CheckApplyStatusResponseValidationError) Reason() string { return e.reason }
+
+// Cause function returns cause value.
+func (e CheckApplyStatusResponseValidationError) Cause() error { return e.cause }
+
+// Key function returns key value.
+func (e CheckApplyStatusResponseValidationError) Key() bool { return e.key }
+
+// ErrorName returns error name.
+func (e CheckApplyStatusResponseValidationError) ErrorName() string {
+	return "CheckApplyStatusResponseValidationError"
+}
+
+// Error satisfies the builtin error interface
+func (e CheckApplyStatusResponseValidationError) Error() string {
+	cause := ""
+	if e.cause != nil {
+		cause = fmt.Sprintf(" | caused by: %v", e.cause)
+	}
+
+	key := ""
+	if e.key {
+		key = "key for "
+	}
+
+	return fmt.Sprintf(
+		"invalid %sCheckApplyStatusResponse.%s: %s%s",
+		key,
+		e.field,
+		e.reason,
+		cause)
+}
+
+var _ error = CheckApplyStatusResponseValidationError{}
+
+var _ interface {
+	Field() string
+	Reason() string
+	Key() bool
+	Cause() error
+	ErrorName() string
+} = CheckApplyStatusResponseValidationError{}
 
 // Validate checks the field values on ApplyResponse with the rules defined in
 // the proto definition for this message. If any rules are violated, the first

--- a/api/proto/project/project.proto
+++ b/api/proto/project/project.proto
@@ -49,6 +49,32 @@ message AllContainersResponse {
   repeated types.StateContainer items = 1;
 }
 
+// ContainerFailure 描述部署判定 FAILED 时失败容器的诊断信息（含日志尾部）。
+message ContainerFailure {
+  string kind      = 1; // 工作负载类型: Deployment/StatefulSet/DaemonSet
+  string workload  = 2; // 工作负载名
+  string pod       = 3; // 失败 pod 名
+  string container = 4; // 失败容器名
+  string reason    = 5; // 失败原因: CrashLoopBackOff/ImagePullBackOff/Error/OOMKilled/Evicted
+  string message   = 6; // 容器状态 message（容器从未启动无日志时兜底展示）
+  string logs      = 7; // 容器日志尾部（CrashLoopBackOff 取上一次崩溃日志）
+}
+
+message CheckApplyStatusRequest {
+  int32 id = 1 [(validate.rules).int32.gt = 0, (google.api.field_behavior) = REQUIRED];
+}
+message CheckApplyStatusResponse {
+  // 聚合判定，复用 types.Deploy：StatusDeployed=正常 / StatusFailed=失败 /
+  // StatusDeploying=进行中 / StatusUnknown=未知（无工作负载或项目未部署）
+  types.Deploy status = 1;
+  // 汇总原因（失败/进行中时的人类可读描述）
+  string reason = 2;
+  // 项目容器明细（含 is_old 新旧标记），前端可复用 AllContainers 的渲染
+  repeated types.StateContainer containers = 3;
+  // 判定为 FAILED 时的具体失败容器列表
+  repeated ContainerFailure failures = 4;
+}
+
 message ApplyResponse {
   websocket.Metadata metadata = 1;
   types.ProjectModel project  = 2;
@@ -161,6 +187,19 @@ service Project {
   rpc AllContainers(AllContainersRequest) returns (AllContainersResponse) {
     option (google.api.http) = {
       get: "/api/projects/{id}/containers"
+    };
+  }
+
+  // CheckApplyStatus 判定项目最近一次部署后新版本容器是否正常运行。
+  // 用于非原子部署（WebApply）后判断部署成功/失败/进行中：
+  // 通过工作负载实时状态（Deployment/StatefulSet/DaemonSet 的 updated/available replicas）
+  // 与最新版本 pod 容器状态聚合判定，避免过渡窗口误报。
+  rpc CheckApplyStatus(CheckApplyStatusRequest) returns (CheckApplyStatusResponse) {
+    option (google.api.http) = {
+      get: "/api/projects/{id}/apply_status"
+    };
+    option (openapi.v3.operation) = {
+      summary: "检查项目部署后的容器运行状态",
     };
   }
 }

--- a/api/proto/project/project_grpc.pb.go
+++ b/api/proto/project/project_grpc.pb.go
@@ -28,6 +28,7 @@ const (
 	Project_Version_FullMethodName               = "/project.Project/Version"
 	Project_Delete_FullMethodName                = "/project.Project/Delete"
 	Project_AllContainers_FullMethodName         = "/project.Project/AllContainers"
+	Project_CheckApplyStatus_FullMethodName      = "/project.Project/CheckApplyStatus"
 )
 
 // ProjectClient is the client API for Project service.
@@ -49,6 +50,11 @@ type ProjectClient interface {
 	Delete(ctx context.Context, in *DeleteRequest, opts ...grpc.CallOption) (*DeleteResponse, error)
 	// AllContainers 获取项目下的所有 pod
 	AllContainers(ctx context.Context, in *AllContainersRequest, opts ...grpc.CallOption) (*AllContainersResponse, error)
+	// CheckApplyStatus 判定项目最近一次部署后新版本容器是否正常运行。
+	// 用于非原子部署（WebApply）后判断部署成功/失败/进行中：
+	// 通过工作负载实时状态（Deployment/StatefulSet/DaemonSet 的 updated/available replicas）
+	// 与最新版本 pod 容器状态聚合判定，避免过渡窗口误报。
+	CheckApplyStatus(ctx context.Context, in *CheckApplyStatusRequest, opts ...grpc.CallOption) (*CheckApplyStatusResponse, error)
 }
 
 type projectClient struct {
@@ -148,6 +154,16 @@ func (c *projectClient) AllContainers(ctx context.Context, in *AllContainersRequ
 	return out, nil
 }
 
+func (c *projectClient) CheckApplyStatus(ctx context.Context, in *CheckApplyStatusRequest, opts ...grpc.CallOption) (*CheckApplyStatusResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CheckApplyStatusResponse)
+	err := c.cc.Invoke(ctx, Project_CheckApplyStatus_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ProjectServer is the server API for Project service.
 // All implementations must embed UnimplementedProjectServer
 // for forward compatibility.
@@ -167,6 +183,11 @@ type ProjectServer interface {
 	Delete(context.Context, *DeleteRequest) (*DeleteResponse, error)
 	// AllContainers 获取项目下的所有 pod
 	AllContainers(context.Context, *AllContainersRequest) (*AllContainersResponse, error)
+	// CheckApplyStatus 判定项目最近一次部署后新版本容器是否正常运行。
+	// 用于非原子部署（WebApply）后判断部署成功/失败/进行中：
+	// 通过工作负载实时状态（Deployment/StatefulSet/DaemonSet 的 updated/available replicas）
+	// 与最新版本 pod 容器状态聚合判定，避免过渡窗口误报。
+	CheckApplyStatus(context.Context, *CheckApplyStatusRequest) (*CheckApplyStatusResponse, error)
 	mustEmbedUnimplementedProjectServer()
 }
 
@@ -200,6 +221,9 @@ func (UnimplementedProjectServer) Delete(context.Context, *DeleteRequest) (*Dele
 }
 func (UnimplementedProjectServer) AllContainers(context.Context, *AllContainersRequest) (*AllContainersResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AllContainers not implemented")
+}
+func (UnimplementedProjectServer) CheckApplyStatus(context.Context, *CheckApplyStatusRequest) (*CheckApplyStatusResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CheckApplyStatus not implemented")
 }
 func (UnimplementedProjectServer) mustEmbedUnimplementedProjectServer() {}
 func (UnimplementedProjectServer) testEmbeddedByValue()                 {}
@@ -359,6 +383,24 @@ func _Project_AllContainers_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Project_CheckApplyStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CheckApplyStatusRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ProjectServer).CheckApplyStatus(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Project_CheckApplyStatus_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ProjectServer).CheckApplyStatus(ctx, req.(*CheckApplyStatusRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Project_ServiceDesc is the grpc.ServiceDesc for Project service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -393,6 +435,10 @@ var Project_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "AllContainers",
 			Handler:    _Project_AllContainers_Handler,
+		},
+		{
+			MethodName: "CheckApplyStatus",
+			Handler:    _Project_CheckApplyStatus_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/doc/openapi.yaml
+++ b/doc/openapi.yaml
@@ -4,7 +4,7 @@
 openapi: 3.0.3
 info:
     title: mars api.
-    version: api/v6.0.0-beta
+    version: v6.0.0-beta.2
 paths:
     /api/access_tokens:
         get:
@@ -1382,6 +1382,37 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/google.rpc.Status'
+    /api/projects/{id}/apply_status:
+        get:
+            tags:
+                - Project
+            summary: 检查项目部署后的容器运行状态
+            description: |-
+                CheckApplyStatus 判定项目最近一次部署后新版本容器是否正常运行。
+                 用于非原子部署（WebApply）后判断部署成功/失败/进行中：
+                 通过工作负载实时状态（Deployment/StatefulSet/DaemonSet 的 updated/available replicas）
+                 与最新版本 pod 容器状态聚合判定，避免过渡窗口误报。
+            operationId: Project_CheckApplyStatus
+            parameters:
+                - name: id
+                  in: path
+                  required: true
+                  schema:
+                    type: integer
+                    format: int32
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/project.CheckApplyStatusResponse'
+                default:
+                    description: Default error response
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/google.rpc.Status'
     /api/projects/{id}/containers:
         get:
             tags:
@@ -2333,6 +2364,51 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/types.StateContainer'
+        project.CheckApplyStatusResponse:
+            type: object
+            properties:
+                status:
+                    enum:
+                        - StatusUnknown
+                        - StatusDeploying
+                        - StatusDeployed
+                        - StatusFailed
+                    type: string
+                    description: |-
+                        聚合判定，复用 types.Deploy：StatusDeployed=正常 / StatusFailed=失败 /
+                         StatusDeploying=进行中 / StatusUnknown=未知（无工作负载或项目未部署）
+                    format: enum
+                reason:
+                    type: string
+                    description: 汇总原因（失败/进行中时的人类可读描述）
+                containers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/types.StateContainer'
+                    description: 项目容器明细（含 is_old 新旧标记），前端可复用 AllContainers 的渲染
+                failures:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/project.ContainerFailure'
+                    description: 判定为 FAILED 时的具体失败容器列表
+        project.ContainerFailure:
+            type: object
+            properties:
+                kind:
+                    type: string
+                workload:
+                    type: string
+                pod:
+                    type: string
+                container:
+                    type: string
+                reason:
+                    type: string
+                message:
+                    type: string
+                logs:
+                    type: string
+            description: ContainerFailure 描述部署判定 FAILED 时失败容器的诊断信息（含日志尾部）。
         project.DeleteResponse:
             type: object
             properties: {}

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -783,6 +783,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/projects/{id}/apply_status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 检查项目部署后的容器运行状态
+         * @description CheckApplyStatus 判定项目最近一次部署后新版本容器是否正常运行。
+         *      用于非原子部署（WebApply）后判断部署成功/失败/进行中：
+         *      通过工作负载实时状态（Deployment/StatefulSet/DaemonSet 的 updated/available replicas）
+         *      与最新版本 pod 容器状态聚合判定，避免过渡窗口误报。
+         */
+        get: operations["Project_CheckApplyStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/projects/{id}/containers": {
         parameters: {
             query?: never;
@@ -1276,6 +1299,31 @@ export interface components {
         };
         "project.AllContainersResponse": {
             items: components["schemas"]["types.StateContainer"][];
+        };
+        "project.CheckApplyStatusResponse": {
+            /**
+             * Format: enum
+             * @description 聚合判定，复用 types.Deploy：StatusDeployed=正常 / StatusFailed=失败 /
+             *      StatusDeploying=进行中 / StatusUnknown=未知（无工作负载或项目未部署）
+             * @enum {string}
+             */
+            status: ProjectCheckApplyStatusResponseStatus;
+            /** @description 汇总原因（失败/进行中时的人类可读描述） */
+            reason: string;
+            /** @description 项目容器明细（含 is_old 新旧标记），前端可复用 AllContainers 的渲染 */
+            containers: components["schemas"]["types.StateContainer"][];
+            /** @description 判定为 FAILED 时的具体失败容器列表 */
+            failures: components["schemas"]["project.ContainerFailure"][];
+        };
+        /** @description ContainerFailure 描述部署判定 FAILED 时失败容器的诊断信息（含日志尾部）。 */
+        "project.ContainerFailure": {
+            kind: string;
+            workload: string;
+            pod: string;
+            container: string;
+            reason: string;
+            message: string;
+            logs: string;
         };
         "project.DeleteResponse": Record<string, never>;
         "project.ListResponse": {
@@ -3231,6 +3279,37 @@ export interface operations {
             };
         };
     };
+    Project_CheckApplyStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["project.CheckApplyStatusResponse"];
+                };
+            };
+            /** @description Default error response */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["google.rpc.Status"];
+                };
+            };
+        };
+    };
     Project_AllContainers: {
         parameters: {
             query?: never;
@@ -3639,6 +3718,12 @@ export enum MarsElementType {
     ElementTypeTextArea = "ElementTypeTextArea",
     ElementTypeNumberSelect = "ElementTypeNumberSelect",
     ElementTypeNumberRadio = "ElementTypeNumberRadio"
+}
+export enum ProjectCheckApplyStatusResponseStatus {
+    StatusUnknown = "StatusUnknown",
+    StatusDeploying = "StatusDeploying",
+    StatusDeployed = "StatusDeployed",
+    StatusFailed = "StatusFailed"
 }
 export enum TypesEventModelAction {
     Unknown = "Unknown",

--- a/internal/biz/apply_status.go
+++ b/internal/biz/apply_status.go
@@ -1,0 +1,421 @@
+package biz
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/duc-cnzj/mars/api/v6/proto/types"
+	"github.com/duc-cnzj/mars/v6/internal/errs"
+	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kmetatypes "k8s.io/apimachinery/pkg/types"
+)
+
+// deploymentRevisionAnnotation 是 ReplicaSet 上记录其 revision 的注解键。
+// k8s.io/api/apps/v1 未导出该常量，故本地定义（值不可变）。
+const deploymentRevisionAnnotation = "deployment.kubernetes.io/revision"
+
+// tailLogLines 拉取失败容器日志的尾部行数。
+const tailLogLines = 200
+
+// ContainerFailure 描述部署判定 FAILED 时失败容器的诊断信息（含日志尾部）。
+type ContainerFailure struct {
+	Kind      string // 工作负载类型: Deployment/StatefulSet/DaemonSet
+	Workload  string // 工作负载名
+	Pod       string // 失败 pod 名
+	Container string // 失败容器名（pod 级失败如 Evicted 时为空）
+	Reason    string // 失败原因: CrashLoopBackOff/ImagePullBackOff/Error/OOMKilled/Evicted 等
+	Message   string // 容器状态 message（容器从未启动无日志时兜底展示）
+	Logs      string // 容器日志尾部（CrashLoopBackOff 取上一次崩溃日志）
+}
+
+// ApplyStatus 是 CheckApplyStatus 的领域返回：聚合判定 + 原因 + 容器明细 + 失败诊断。
+type ApplyStatus struct {
+	Status     types.Deploy
+	Reason     string
+	Containers []*types.StateContainer
+	Failures   []*ContainerFailure
+}
+
+// failedContainerRef 是纯扫描产物：失败容器定位与原因（日志另由上层拉取，保持纯函数可测）。
+type failedContainerRef struct {
+	Kind, Workload, Pod, Container, Reason, Message string
+}
+
+// fatalWaitingReasons 是容器进入等待态后需要判定为失败的稳定 reason。
+// ContainerCreating/ErrImagePull 等瞬时态不计入，避免把拉镜像的瞬时状态误报成失败。
+var fatalWaitingReasons = map[string]struct{}{
+	"CrashLoopBackOff":           {},
+	"ImagePullBackOff":           {},
+	"CreateContainerConfigError": {},
+	"InvalidImageName":           {},
+	"RunContainerError":          {},
+}
+
+// fatalTerminatedReasons 是容器终止态需要判定为失败的 reason。
+var fatalTerminatedReasons = map[string]struct{}{
+	"Error":              {},
+	"OOMKilled":          {},
+	"ContainerCannotRun": {},
+}
+
+// CheckApplyStatus 判定项目最近一次部署后新版本容器是否正常运行。
+// 解析项目 manifests 里的 Deployment/StatefulSet/DaemonSet，逐个读取实时状态与
+// 最新版本 pod 容器状态，聚合出 Deployed/Deploying/Failed/Unknown 判定：
+// 任一工作负载 Failed → 整体 Failed，否则任一 Deploying → 整体 Deploying，全正常才 Deployed。
+// 旧版本 pod 异常（Evicted/终止中）属滚动清理过程，不影响新版本判定。
+func (p *projectBiz) CheckApplyStatus(ctx context.Context, id int) (*ApplyStatus, error) {
+	proj, err := p.projRepo.Show(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	containers, err := buildStateContainers(ctx, p.k8sRepo, proj)
+	if err != nil {
+		return nil, err
+	}
+	deployments, statefulSets, daemonSets := p.k8sRepo.GetWorkloadsByManifest(proj.Manifest)
+	if len(deployments)+len(statefulSets)+len(daemonSets) == 0 {
+		return &ApplyStatus{Status: types.Deploy_StatusUnknown, Reason: "未发现 Deployment/StatefulSet/DaemonSet 工作负载", Containers: containers}, nil
+	}
+	status, reason, failures, err := p.judgeWorkloads(ctx, proj.Namespace.Name, deployments, statefulSets, daemonSets)
+	if err != nil {
+		return nil, err
+	}
+	return &ApplyStatus{Status: status, Reason: reason, Containers: containers, Failures: failures}, nil
+}
+
+// judgeWorkloads 逐个判定三类工作负载的滚动状态并聚合：
+// Failed 优先，其次 Deploying；全部 Deployed 才返回 Deployed。
+func (p *projectBiz) judgeWorkloads(ctx context.Context, ns string, deployments []*appsv1.Deployment, statefulSets []*appsv1.StatefulSet, daemonSets []*appsv1.DaemonSet) (types.Deploy, string, []*ContainerFailure, error) {
+	status := types.Deploy_StatusDeployed
+	var reasons []string
+	var failures []*ContainerFailure
+
+	// mark 聚合单个工作负载的判定：失败优先、进行中次之、Deployed 不改变整体。
+	mark := func(st types.Deploy, reason string, fails []*ContainerFailure) {
+		switch st {
+		case types.Deploy_StatusFailed:
+			status = types.Deploy_StatusFailed
+			reasons = append(reasons, reason)
+			failures = append(failures, fails...)
+		case types.Deploy_StatusDeploying:
+			if status != types.Deploy_StatusFailed {
+				status = types.Deploy_StatusDeploying
+				reasons = append(reasons, reason)
+			}
+		}
+	}
+
+	// Deployment 需最新 ReplicaSet 定位新版本 pod，RS 列表统一取一次。
+	var (
+		rss []*appsv1.ReplicaSet
+		err error
+	)
+	if len(deployments) > 0 {
+		rss, err = p.k8sRepo.ListReplicaSets(ns)
+		if err != nil {
+			return 0, "", nil, err
+		}
+	}
+
+	for _, wl := range deployments {
+		live, err := p.k8sRepo.GetDeployment(ns, wl.Name)
+		if err != nil {
+			if errs.IsNotFound(err) {
+				mark(types.Deploy_StatusDeploying, "Deployment "+wl.Name+" 尚未创建", nil)
+				continue
+			}
+			return 0, "", nil, err
+		}
+		st, reason, fails := judgeDeploymentRollout(live, rss, p.podsByWorkload(ns, wl.Spec.Selector))
+		mark(st, "Deployment "+wl.Name+": "+reason, toDomainFailures(fails, "Deployment", wl.Name))
+	}
+
+	for _, wl := range statefulSets {
+		live, err := p.k8sRepo.GetStatefulSet(ns, wl.Name)
+		if err != nil {
+			if errs.IsNotFound(err) {
+				mark(types.Deploy_StatusDeploying, "StatefulSet "+wl.Name+" 尚未创建", nil)
+				continue
+			}
+			return 0, "", nil, err
+		}
+		st, reason, fails := judgeStatefulSetRollout(live, p.podsByWorkload(ns, wl.Spec.Selector))
+		mark(st, "StatefulSet "+wl.Name+": "+reason, toDomainFailures(fails, "StatefulSet", wl.Name))
+	}
+
+	for _, wl := range daemonSets {
+		live, err := p.k8sRepo.GetDaemonSet(ns, wl.Name)
+		if err != nil {
+			if errs.IsNotFound(err) {
+				mark(types.Deploy_StatusDeploying, "DaemonSet "+wl.Name+" 尚未创建", nil)
+				continue
+			}
+			return 0, "", nil, err
+		}
+		st, reason, fails := judgeDaemonSetRollout(live, p.podsByWorkload(ns, wl.Spec.Selector))
+		mark(st, "DaemonSet "+wl.Name+": "+reason, toDomainFailures(fails, "DaemonSet", wl.Name))
+	}
+
+	if status == types.Deploy_StatusFailed {
+		p.fillFailureLogs(ctx, ns, failures)
+	}
+	return status, strings.Join(reasons, "; "), failures, nil
+}
+
+// judgeDeploymentRollout 依据 Deployment 实时状态与最新版本 pod 判定滚动结果。
+// 旧版本 pod 异常不影响判定；新版本 pod 失败优先于计数判定，避免计数一致但容器故障时误报成功。
+func judgeDeploymentRollout(dep *appsv1.Deployment, rss []*appsv1.ReplicaSet, pods []*corev1.Pod) (types.Deploy, string, []failedContainerRef) {
+	desired := int32(0)
+	if dep.Spec.Replicas != nil {
+		desired = *dep.Spec.Replicas
+	}
+	if desired == 0 {
+		return types.Deploy_StatusDeployed, "副本数为 0，无容器需验证", nil
+	}
+	// 控制器尚未收敛到最新 spec，直接判进行中
+	if dep.Status.ObservedGeneration < dep.Generation {
+		return types.Deploy_StatusDeploying, "控制器尚未完成对账", nil
+	}
+	// 过渡窗口：最新 spec 已提交但新版本 pod 一个都没创建，绝不算成功
+	if dep.Status.UpdatedReplicas == 0 {
+		return types.Deploy_StatusDeploying, "新版本 pod 尚未创建", nil
+	}
+	if fails := collectPodFailures(deploymentNewPods(dep, rss, pods)); len(fails) > 0 {
+		return types.Deploy_StatusFailed, formatReason(fails), fails
+	}
+	if dep.Status.UpdatedReplicas == desired && dep.Status.AvailableReplicas == desired {
+		return types.Deploy_StatusDeployed, "", nil
+	}
+	return types.Deploy_StatusDeploying, fmt.Sprintf("滚动进行中 %d/%d 就绪", dep.Status.AvailableReplicas, desired), nil
+}
+
+// judgeStatefulSetRollout 依据 StatefulSet 实时状态与最新版本 pod 判定滚动结果。
+func judgeStatefulSetRollout(sts *appsv1.StatefulSet, pods []*corev1.Pod) (types.Deploy, string, []failedContainerRef) {
+	desired := int32(0)
+	if sts.Spec.Replicas != nil {
+		desired = *sts.Spec.Replicas
+	}
+	if desired == 0 {
+		return types.Deploy_StatusDeployed, "副本数为 0，无容器需验证", nil
+	}
+	if sts.Status.ObservedGeneration < sts.Generation {
+		return types.Deploy_StatusDeploying, "控制器尚未完成对账", nil
+	}
+	if sts.Status.UpdatedReplicas == 0 {
+		return types.Deploy_StatusDeploying, "新版本 pod 尚未创建", nil
+	}
+	if fails := collectPodFailures(statefulSetNewPods(sts, pods)); len(fails) > 0 {
+		return types.Deploy_StatusFailed, formatReason(fails), fails
+	}
+	if sts.Status.UpdatedReplicas == desired && sts.Status.AvailableReplicas == desired {
+		return types.Deploy_StatusDeployed, "", nil
+	}
+	return types.Deploy_StatusDeploying, fmt.Sprintf("滚动进行中 %d/%d 就绪", sts.Status.AvailableReplicas, desired), nil
+}
+
+// judgeDaemonSetRollout 依据 DaemonSet 实时状态与最新版本 pod 判定滚动结果。
+func judgeDaemonSetRollout(ds *appsv1.DaemonSet, pods []*corev1.Pod) (types.Deploy, string, []failedContainerRef) {
+	desired := ds.Status.DesiredNumberScheduled
+	if desired == 0 {
+		return types.Deploy_StatusDeployed, "无节点需调度，无容器需验证", nil
+	}
+	if ds.Status.ObservedGeneration < ds.Generation {
+		return types.Deploy_StatusDeploying, "控制器尚未完成对账", nil
+	}
+	if ds.Status.UpdatedNumberScheduled == 0 {
+		return types.Deploy_StatusDeploying, "新版本 pod 尚未创建", nil
+	}
+	if fails := collectPodFailures(daemonSetNewPods(pods)); len(fails) > 0 {
+		return types.Deploy_StatusFailed, formatReason(fails), fails
+	}
+	if ds.Status.UpdatedNumberScheduled == desired && ds.Status.NumberAvailable == desired {
+		return types.Deploy_StatusDeployed, "", nil
+	}
+	return types.Deploy_StatusDeploying, fmt.Sprintf("滚动进行中 %d/%d 就绪", ds.Status.NumberAvailable, desired), nil
+}
+
+// deploymentNewPods 返回 Deployment 下最新 revision ReplicaSet 所管理的 pod（新版本 pod）。
+func deploymentNewPods(dep *appsv1.Deployment, rss []*appsv1.ReplicaSet, pods []*corev1.Pod) []*corev1.Pod {
+	latest := latestReplicaSet(dep, rss)
+	if latest == nil {
+		return nil
+	}
+	return ownedByRS(pods, latest.UID)
+}
+
+// latestReplicaSet 返回 Deployment 下 revision 注解最大的 ReplicaSet；无则返回 nil。
+func latestReplicaSet(dep *appsv1.Deployment, rss []*appsv1.ReplicaSet) *appsv1.ReplicaSet {
+	var latest *appsv1.ReplicaSet
+	for _, rs := range rss {
+		if !ownedBy(rs, dep.UID) {
+			continue
+		}
+		if latest == nil || revisionOf(rs) > revisionOf(latest) {
+			latest = rs
+		}
+	}
+	return latest
+}
+
+// revisionOf 解析 ReplicaSet 的 deployment.kubernetes.io/revision 注解为整数，解析失败返回 0。
+func revisionOf(rs *appsv1.ReplicaSet) int {
+	rev, err := strconv.Atoi(rs.Annotations[deploymentRevisionAnnotation])
+	if err != nil {
+		return 0
+	}
+	return rev
+}
+
+// statefulSetNewPods 返回 StatefulSet 当前更新版本
+// （controller-revision-hash == status.updateRevision）的 pod。
+func statefulSetNewPods(sts *appsv1.StatefulSet, pods []*corev1.Pod) []*corev1.Pod {
+	rev := sts.Status.UpdateRevision
+	if rev == "" {
+		return nil
+	}
+	var res []*corev1.Pod
+	for _, pod := range pods {
+		if pod.Labels[appsv1.ControllerRevisionHashLabelKey] == rev {
+			res = append(res, pod)
+		}
+	}
+	return res
+}
+
+// daemonSetNewPods 以 controller-revision-hash 分组、按创建时间最新的一组作为新版本 pod。
+// DaemonSet 状态无 revision 字段，滚动中最新创建的 pod 必属新模板，属合理近似。
+func daemonSetNewPods(pods []*corev1.Pod) []*corev1.Pod {
+	byHash := make(map[string][]*corev1.Pod)
+	var newestHash string
+	var newest time.Time
+	for _, pod := range pods {
+		hash := pod.Labels[appsv1.ControllerRevisionHashLabelKey]
+		if hash == "" {
+			continue
+		}
+		byHash[hash] = append(byHash[hash], pod)
+		created := pod.CreationTimestamp.Time
+		if newest.IsZero() || created.After(newest) {
+			newest = created
+			newestHash = hash
+		}
+	}
+	if newestHash == "" {
+		return pods
+	}
+	return byHash[newestHash]
+}
+
+// ownedBy 判断 obj 是否被指定 UID 的属主直接拥有。
+func ownedBy(obj metav1.Object, uid kmetatypes.UID) bool {
+	for _, ref := range obj.GetOwnerReferences() {
+		if ref.UID == uid {
+			return true
+		}
+	}
+	return false
+}
+
+// ownedByRS 过滤出 OwnerReference 包含指定 ReplicaSet UID 的 pod。
+func ownedByRS(pods []*corev1.Pod, uid kmetatypes.UID) []*corev1.Pod {
+	var res []*corev1.Pod
+	for _, pod := range pods {
+		if ownedBy(pod, uid) {
+			res = append(res, pod)
+		}
+	}
+	return res
+}
+
+// collectPodFailures 纯函数：从 pod 状态推断失败容器（不触发任何 k8s 调用）。
+// pod 级失败（Failed/Evicted）记一条无容器名的失败；容器级失败按稳定 reason 判定。
+func collectPodFailures(pods []*corev1.Pod) []failedContainerRef {
+	var refs []failedContainerRef
+	for _, pod := range pods {
+		if pod.Status.Phase == corev1.PodFailed {
+			reason := pod.Status.Reason
+			if reason == "" {
+				reason = "PodFailed"
+			}
+			refs = append(refs, failedContainerRef{Pod: pod.Name, Reason: reason, Message: pod.Status.Message})
+			continue
+		}
+		for _, cs := range pod.Status.ContainerStatuses {
+			if w := cs.State.Waiting; w != nil && w.Reason != "" {
+				if _, ok := fatalWaitingReasons[w.Reason]; ok {
+					refs = append(refs, failedContainerRef{Pod: pod.Name, Container: cs.Name, Reason: w.Reason, Message: w.Message})
+					continue
+				}
+			}
+			if t := cs.State.Terminated; t != nil && t.Reason != "" {
+				if _, ok := fatalTerminatedReasons[t.Reason]; ok {
+					refs = append(refs, failedContainerRef{Pod: pod.Name, Container: cs.Name, Reason: t.Reason, Message: t.Message})
+				}
+			}
+		}
+	}
+	return refs
+}
+
+// formatReason 把失败容器汇总为人类可读原因（逐条列出，分号分隔）。
+func formatReason(fails []failedContainerRef) string {
+	var parts []string
+	for _, f := range fails {
+		if f.Container != "" {
+			parts = append(parts, fmt.Sprintf("容器 %s 失败: %s", f.Container, f.Reason))
+		} else {
+			parts = append(parts, fmt.Sprintf("pod %s: %s", f.Pod, f.Reason))
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+// toDomainFailures 把纯扫描得到的失败容器转成领域类型并补全工作负载信息。
+func toDomainFailures(fails []failedContainerRef, kind, workload string) []*ContainerFailure {
+	out := make([]*ContainerFailure, 0, len(fails))
+	for _, f := range fails {
+		out = append(out, &ContainerFailure{
+			Kind: kind, Workload: workload, Pod: f.Pod, Container: f.Container,
+			Reason: f.Reason, Message: f.Message,
+		})
+	}
+	return out
+}
+
+// fillFailureLogs 为失败容器补拉日志尾部：
+// CrashLoopBackOff 取上一次崩溃实例的日志；容器从未启动（如 ImagePullBackOff）时
+// 日志拉取失败仅降级为 message，不改变判定。
+func (p *projectBiz) fillFailureLogs(ctx context.Context, ns string, failures []*ContainerFailure) {
+	for _, f := range failures {
+		if f.Container == "" {
+			continue
+		}
+		opts := &corev1.PodLogOptions{
+			TailLines: lo.ToPtr(int64(tailLogLines)),
+			Container: f.Container,
+			Previous:  f.Reason == "CrashLoopBackOff",
+		}
+		logs, err := p.k8sRepo.GetPodLogs(ctx, ns, f.Pod, opts)
+		if err != nil {
+			continue
+		}
+		f.Logs = strings.TrimSpace(logs)
+	}
+}
+
+// podsByWorkload 按工作负载 selector 列出命名空间内 pod；selector 解析失败返回 nil
+// （manifest 中合法对象的 selector 必然可解析，此为防御分支）。
+func (p *projectBiz) podsByWorkload(ns string, sel *metav1.LabelSelector) []*corev1.Pod {
+	parsed, err := metav1.LabelSelectorAsSelector(sel)
+	if err != nil {
+		return nil
+	}
+	pods, _ := p.k8sRepo.ListPodsBySelectors(ns, []string{parsed.String()})
+	return pods
+}

--- a/internal/biz/apply_status_test.go
+++ b/internal/biz/apply_status_test.go
@@ -1,0 +1,879 @@
+package biz
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/duc-cnzj/mars/api/v6/proto/types"
+	"github.com/duc-cnzj/mars/v6/internal/errs"
+	"github.com/duc-cnzj/mars/v6/internal/mlog"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kmetatypes "k8s.io/apimachinery/pkg/types"
+)
+
+// ---------- 构造器 ----------
+
+// newDepForTest 构造一个 observed 已收敛、指定 updated/available/desired 的 Deployment。
+func newDepForTest(updated, available, desired int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "dep", Namespace: "ns", Generation: 2},
+		Spec:       appsv1.DeploymentSpec{Replicas: lo.ToPtr(desired)},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 2, UpdatedReplicas: updated, AvailableReplicas: available,
+		},
+	}
+}
+
+// newStsForTest 构造一个 observed 已收敛、指定 updated/available/desired 与 updateRevision 的 StatefulSet。
+func newStsForTest(updated, available, desired int32, updateRevision string) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "sts", Namespace: "ns", Generation: 2},
+		Spec:       appsv1.StatefulSetSpec{Replicas: lo.ToPtr(desired)},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 2, UpdatedReplicas: updated, AvailableReplicas: available,
+			UpdateRevision: updateRevision,
+		},
+	}
+}
+
+// newDsForTest 构造一个 observed 已收敛、指定 updated/available/desired 的 DaemonSet。
+func newDsForTest(updated, available, desired int32) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "ds", Namespace: "ns", Generation: 2},
+		Status: appsv1.DaemonSetStatus{
+			ObservedGeneration: 2, UpdatedNumberScheduled: updated,
+			NumberAvailable: available, DesiredNumberScheduled: desired,
+		},
+	}
+}
+
+// newRSForTest 构造被 depUID 拥有的 ReplicaSet，带 revision 注解。
+func newRSForTest(uid, revision, depUID string) *appsv1.ReplicaSet {
+	return &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "rs-" + uid, Namespace: "ns", UID: kmetatypes.UID(uid),
+			Annotations:     map[string]string{deploymentRevisionAnnotation: revision},
+			OwnerReferences: []metav1.OwnerReference{{Kind: "Deployment", UID: kmetatypes.UID(depUID)}},
+		},
+	}
+}
+
+// rsPodForTest 构造被指定 ReplicaSet UID 拥有、容器处于 waitingReason 等待态的 pod。
+func rsPodForTest(name, rsUID, waitingReason string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "ns",
+			OwnerReferences: []metav1.OwnerReference{{Kind: "ReplicaSet", UID: kmetatypes.UID(rsUID)}},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "web"}}},
+	}
+	if waitingReason != "" {
+		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+			Name:  "web",
+			State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: waitingReason}},
+		}}
+	} else {
+		pod.Status.Phase = corev1.PodRunning
+		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{Name: "web", Ready: true}}
+	}
+	return pod
+}
+
+// ---------- judgeDeploymentRollout ----------
+
+func TestJudgeDeploymentRollout_DesiredZero(t *testing.T) {
+	st, reason, fails := judgeDeploymentRollout(newDepForTest(0, 0, 0), nil, nil)
+	assert.Equal(t, types.Deploy_StatusDeployed, st)
+	assert.Contains(t, reason, "副本数为 0")
+	assert.Empty(t, fails)
+}
+
+func TestJudgeDeploymentRollout_NotObserved(t *testing.T) {
+	dep := newDepForTest(1, 1, 1)
+	dep.Status.ObservedGeneration = 1 // < Generation(2)
+	st, reason, fails := judgeDeploymentRollout(dep, nil, nil)
+	assert.Equal(t, types.Deploy_StatusDeploying, st)
+	assert.Contains(t, reason, "控制器尚未完成对账")
+	assert.Empty(t, fails)
+}
+
+func TestJudgeDeploymentRollout_NoNewPods(t *testing.T) {
+	st, reason, fails := judgeDeploymentRollout(newDepForTest(0, 5, 5), nil, nil)
+	assert.Equal(t, types.Deploy_StatusDeploying, st)
+	assert.Contains(t, reason, "新版本 pod 尚未创建")
+	assert.Empty(t, fails)
+}
+
+func TestJudgeDeploymentRollout_NewPodFailed(t *testing.T) {
+	dep := newDepForTest(1, 0, 1)
+	dep.UID = "dep"
+	rss := []*appsv1.ReplicaSet{newRSForTest("rs-new", "2", "dep")}
+	pods := []*corev1.Pod{rsPodForTest("pod-new", "rs-new", "CrashLoopBackOff")}
+	st, reason, fails := judgeDeploymentRollout(dep, rss, pods)
+	assert.Equal(t, types.Deploy_StatusFailed, st)
+	assert.Contains(t, reason, "CrashLoopBackOff")
+	if assert.Len(t, fails, 1) {
+		assert.Equal(t, "pod-new", fails[0].Pod)
+		assert.Equal(t, "web", fails[0].Container)
+		assert.Equal(t, "CrashLoopBackOff", fails[0].Reason)
+	}
+}
+
+// TestJudgeDeploymentRollout_Progress 覆盖用户关切场景：5 个副本滚动中 3 个就绪，
+// 不应判 Deployed，而应返回 Deploying。
+func TestJudgeDeploymentRollout_Progress(t *testing.T) {
+	st, reason, fails := judgeDeploymentRollout(newDepForTest(3, 3, 5), nil, nil)
+	assert.Equal(t, types.Deploy_StatusDeploying, st)
+	assert.Contains(t, reason, "3/5")
+	assert.Empty(t, fails)
+}
+
+func TestJudgeDeploymentRollout_Deployed(t *testing.T) {
+	st, reason, fails := judgeDeploymentRollout(newDepForTest(3, 3, 3), nil, nil)
+	assert.Equal(t, types.Deploy_StatusDeployed, st)
+	assert.Empty(t, reason)
+	assert.Empty(t, fails)
+}
+
+// ---------- judgeStatefulSetRollout ----------
+
+func TestJudgeStatefulSetRollout_DesiredZero(t *testing.T) {
+	st, reason, fails := judgeStatefulSetRollout(newStsForTest(0, 0, 0, "rev2"), nil)
+	assert.Equal(t, types.Deploy_StatusDeployed, st)
+	assert.Contains(t, reason, "副本数为 0")
+	assert.Empty(t, fails)
+}
+
+func TestJudgeStatefulSetRollout_NotObserved(t *testing.T) {
+	sts := newStsForTest(1, 1, 1, "rev2")
+	sts.Status.ObservedGeneration = 1
+	st, reason, fails := judgeStatefulSetRollout(sts, nil)
+	assert.Equal(t, types.Deploy_StatusDeploying, st)
+	assert.Contains(t, reason, "控制器尚未完成对账")
+	assert.Empty(t, fails)
+}
+
+func TestJudgeStatefulSetRollout_NoNewPods(t *testing.T) {
+	st, reason, fails := judgeStatefulSetRollout(newStsForTest(0, 3, 3, "rev2"), nil)
+	assert.Equal(t, types.Deploy_StatusDeploying, st)
+	assert.Contains(t, reason, "新版本 pod 尚未创建")
+	assert.Empty(t, fails)
+}
+
+// TestJudgeStatefulSetRollout_NewPodFailed 覆盖最新版本 pod（hash==updateRevision）崩溃 → Failed。
+func TestJudgeStatefulSetRollout_NewPodFailed(t *testing.T) {
+	sts := newStsForTest(1, 0, 1, "rev2")
+	pods := []*corev1.Pod{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-sts", Namespace: "ns",
+			Labels: map[string]string{appsv1.ControllerRevisionHashLabelKey: "rev2"},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "web"}}},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+			Name:  "web",
+			State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"}},
+		}}},
+	}}
+	st, reason, fails := judgeStatefulSetRollout(sts, pods)
+	assert.Equal(t, types.Deploy_StatusFailed, st)
+	assert.Contains(t, reason, "ImagePullBackOff")
+	if assert.Len(t, fails, 1) {
+		assert.Equal(t, "pod-sts", fails[0].Pod)
+	}
+}
+
+func TestJudgeStatefulSetRollout_Progress(t *testing.T) {
+	st, reason, fails := judgeStatefulSetRollout(newStsForTest(2, 2, 3, "rev2"), nil)
+	assert.Equal(t, types.Deploy_StatusDeploying, st)
+	assert.Contains(t, reason, "2/3")
+	assert.Empty(t, fails)
+}
+
+func TestJudgeStatefulSetRollout_Deployed(t *testing.T) {
+	st, reason, fails := judgeStatefulSetRollout(newStsForTest(2, 2, 2, "rev2"), nil)
+	assert.Equal(t, types.Deploy_StatusDeployed, st)
+	assert.Empty(t, reason)
+	assert.Empty(t, fails)
+}
+
+// ---------- judgeDaemonSetRollout ----------
+
+func TestJudgeDaemonSetRollout_DesiredZero(t *testing.T) {
+	st, reason, fails := judgeDaemonSetRollout(newDsForTest(0, 0, 0), nil)
+	assert.Equal(t, types.Deploy_StatusDeployed, st)
+	assert.Contains(t, reason, "无节点需调度")
+	assert.Empty(t, fails)
+}
+
+func TestJudgeDaemonSetRollout_NotObserved(t *testing.T) {
+	ds := newDsForTest(2, 2, 2)
+	ds.Status.ObservedGeneration = 1
+	st, reason, fails := judgeDaemonSetRollout(ds, nil)
+	assert.Equal(t, types.Deploy_StatusDeploying, st)
+	assert.Contains(t, reason, "控制器尚未完成对账")
+	assert.Empty(t, fails)
+}
+
+func TestJudgeDaemonSetRollout_NoNewPods(t *testing.T) {
+	st, reason, fails := judgeDaemonSetRollout(newDsForTest(0, 3, 3), nil)
+	assert.Equal(t, types.Deploy_StatusDeploying, st)
+	assert.Contains(t, reason, "新版本 pod 尚未创建")
+	assert.Empty(t, fails)
+}
+
+// TestJudgeDaemonSetRollout_NewPodFailed 覆盖最新 hash 组 pod 崩溃 → Failed。
+func TestJudgeDaemonSetRollout_NewPodFailed(t *testing.T) {
+	ds := newDsForTest(1, 0, 1)
+	pods := []*corev1.Pod{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-ds", Namespace: "ns",
+			Labels: map[string]string{appsv1.ControllerRevisionHashLabelKey: "hash-new"},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "web"}}},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+			Name:  "web",
+			State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "OOMKilled"}},
+		}}},
+	}}
+	st, reason, fails := judgeDaemonSetRollout(ds, pods)
+	assert.Equal(t, types.Deploy_StatusFailed, st)
+	assert.Contains(t, reason, "OOMKilled")
+	if assert.Len(t, fails, 1) {
+		assert.Equal(t, "pod-ds", fails[0].Pod)
+	}
+}
+
+func TestJudgeDaemonSetRollout_Progress(t *testing.T) {
+	st, reason, fails := judgeDaemonSetRollout(newDsForTest(1, 1, 3), nil)
+	assert.Equal(t, types.Deploy_StatusDeploying, st)
+	assert.Contains(t, reason, "1/3")
+	assert.Empty(t, fails)
+}
+
+func TestJudgeDaemonSetRollout_Deployed(t *testing.T) {
+	st, reason, fails := judgeDaemonSetRollout(newDsForTest(3, 3, 3), nil)
+	assert.Equal(t, types.Deploy_StatusDeployed, st)
+	assert.Empty(t, reason)
+	assert.Empty(t, fails)
+}
+
+// ---------- collectPodFailures ----------
+
+func TestCollectPodFailures_PodFailed(t *testing.T) {
+	pods := []*corev1.Pod{{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-failed"},
+		Status:     corev1.PodStatus{Phase: corev1.PodFailed, Reason: "Evicted", Message: "node full"},
+	}}
+	refs := collectPodFailures(pods)
+	if assert.Len(t, refs, 1) {
+		assert.Equal(t, "pod-failed", refs[0].Pod)
+		assert.Empty(t, refs[0].Container)
+		assert.Equal(t, "Evicted", refs[0].Reason)
+		assert.Equal(t, "node full", refs[0].Message)
+	}
+}
+
+func TestCollectPodFailures_PodFailedNoReason(t *testing.T) {
+	refs := collectPodFailures([]*corev1.Pod{{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-failed"},
+		Status:     corev1.PodStatus{Phase: corev1.PodFailed},
+	}})
+	if assert.Len(t, refs, 1) {
+		assert.Equal(t, "PodFailed", refs[0].Reason)
+	}
+}
+
+func TestCollectPodFailures_FatalWaiting(t *testing.T) {
+	for _, reason := range []string{"CrashLoopBackOff", "ImagePullBackOff", "CreateContainerConfigError", "InvalidImageName", "RunContainerError"} {
+		refs := collectPodFailures([]*corev1.Pod{rsPodForTest("p", "rs", reason)})
+		if assert.Len(t, refs, 1, "reason=%s", reason) {
+			assert.Equal(t, reason, refs[0].Reason)
+		}
+	}
+}
+
+func TestCollectPodFailures_FatalTerminated(t *testing.T) {
+	for _, reason := range []string{"Error", "OOMKilled", "ContainerCannotRun"} {
+		pods := []*corev1.Pod{{
+			ObjectMeta: metav1.ObjectMeta{Name: "p"},
+			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "web",
+				State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: reason}},
+			}}},
+		}}
+		refs := collectPodFailures(pods)
+		if assert.Len(t, refs, 1, "reason=%s", reason) {
+			assert.Equal(t, reason, refs[0].Reason)
+		}
+	}
+}
+
+// TestCollectPodFailures_TransientIgnored 覆盖瞬时态不误判：ContainerCreating/ErrImagePull
+// 属拉镜像/创建中的过渡状态，不应报失败。
+func TestCollectPodFailures_TransientIgnored(t *testing.T) {
+	pods := []*corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "p"},
+			Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+				{Name: "web", State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ContainerCreating"}}},
+				{Name: "sidecar", State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ErrImagePull"}}},
+				{Name: "ok", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Completed", ExitCode: 0}}},
+			}},
+		},
+	}
+	assert.Empty(t, collectPodFailures(pods))
+}
+
+// ---------- 新版本 pod 定位辅助 ----------
+
+func TestLatestReplicaSet_PicksMaxRevision(t *testing.T) {
+	dep := newDepForTest(2, 2, 2)
+	dep.UID = "dep-uid"
+	rss := []*appsv1.ReplicaSet{
+		newRSForTest("rs-1", "1", "dep-uid"),
+		newRSForTest("rs-2", "2", "dep-uid"),
+	}
+	latest := latestReplicaSet(dep, rss)
+	assert.NotNil(t, latest)
+	assert.Equal(t, kmetatypes.UID("rs-2"), latest.UID)
+}
+
+func TestLatestReplicaSet_IgnoresForeign(t *testing.T) {
+	dep := newDepForTest(1, 1, 1)
+	dep.UID = "dep-uid"
+	rss := []*appsv1.ReplicaSet{newRSForTest("rs-other", "99", "other-dep")}
+	assert.Nil(t, latestReplicaSet(dep, rss))
+}
+
+func TestLatestReplicaSet_Empty(t *testing.T) {
+	assert.Nil(t, latestReplicaSet(newDepForTest(0, 0, 0), nil))
+}
+
+func TestRevisionOf(t *testing.T) {
+	rs := newRSForTest("rs", "7", "dep")
+	assert.Equal(t, 7, revisionOf(rs))
+	rs.Annotations[deploymentRevisionAnnotation] = "abc"
+	assert.Equal(t, 0, revisionOf(rs))
+	assert.Equal(t, 0, revisionOf(&appsv1.ReplicaSet{}))
+}
+
+func TestDeploymentNewPods(t *testing.T) {
+	dep := newDepForTest(2, 2, 2)
+	dep.UID = "dep-uid"
+	rss := []*appsv1.ReplicaSet{
+		newRSForTest("rs-old", "1", "dep-uid"),
+		newRSForTest("rs-new", "2", "dep-uid"),
+	}
+	pods := []*corev1.Pod{
+		rsPodForTest("old", "rs-old", ""),
+		rsPodForTest("new", "rs-new", ""),
+		rsPodForTest("other", "rs-other", ""),
+	}
+	got := deploymentNewPods(dep, rss, pods)
+	assert.Len(t, got, 1)
+	assert.Equal(t, "new", got[0].Name)
+}
+
+func TestDeploymentNewPods_NoLatestRS(t *testing.T) {
+	dep := newDepForTest(1, 1, 1)
+	dep.UID = "dep-uid"
+	assert.Nil(t, deploymentNewPods(dep, []*appsv1.ReplicaSet{newRSForTest("rs", "1", "other")}, []*corev1.Pod{rsPodForTest("p", "rs", "")}))
+}
+
+func TestStatefulSetNewPods(t *testing.T) {
+	sts := newStsForTest(2, 2, 2, "rev2")
+	pods := []*corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "old", Labels: map[string]string{appsv1.ControllerRevisionHashLabelKey: "rev1"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "new", Labels: map[string]string{appsv1.ControllerRevisionHashLabelKey: "rev2"}}},
+	}
+	got := statefulSetNewPods(sts, pods)
+	assert.Len(t, got, 1)
+	assert.Equal(t, "new", got[0].Name)
+}
+
+func TestStatefulSetNewPods_EmptyRevision(t *testing.T) {
+	sts := newStsForTest(0, 0, 0, "")
+	assert.Nil(t, statefulSetNewPods(sts, nil))
+}
+
+func TestDaemonSetNewPods_NewestGroup(t *testing.T) {
+	now := time.Now()
+	pods := []*corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "old", CreationTimestamp: metav1.Time{Time: now.Add(-time.Hour)}, Labels: map[string]string{appsv1.ControllerRevisionHashLabelKey: "old-hash"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "new", CreationTimestamp: metav1.Time{Time: now}, Labels: map[string]string{appsv1.ControllerRevisionHashLabelKey: "new-hash"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "new2", CreationTimestamp: metav1.Time{Time: now.Add(time.Minute)}, Labels: map[string]string{appsv1.ControllerRevisionHashLabelKey: "new-hash"}}},
+	}
+	got := daemonSetNewPods(pods)
+	assert.ElementsMatch(t, []string{"new", "new2"}, lo.Map(got, func(p *corev1.Pod, _ int) string { return p.Name }))
+}
+
+func TestDaemonSetNewPods_NoHashFallback(t *testing.T) {
+	pods := []*corev1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: "p1"}}, {ObjectMeta: metav1.ObjectMeta{Name: "p2"}}}
+	got := daemonSetNewPods(pods)
+	assert.Len(t, got, 2)
+}
+
+func TestOwnedBy(t *testing.T) {
+	obj := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{UID: "a"}, {UID: "b"}}}}
+	assert.True(t, ownedBy(obj, "a"))
+	assert.True(t, ownedBy(obj, "b"))
+	assert.False(t, ownedBy(obj, "c"))
+	assert.False(t, ownedBy(&corev1.Pod{}, "a"))
+}
+
+func TestOwnedByRS(t *testing.T) {
+	pods := []*corev1.Pod{
+		rsPodForTest("m1", "rs", ""),
+		rsPodForTest("m2", "rs", ""),
+		rsPodForTest("other", "rs-other", ""),
+	}
+	got := ownedByRS(pods, "rs")
+	assert.ElementsMatch(t, []string{"m1", "m2"}, lo.Map(got, func(p *corev1.Pod, _ int) string { return p.Name }))
+}
+
+// ---------- formatReason / toDomainFailures ----------
+
+func TestFormatReason(t *testing.T) {
+	got := formatReason([]failedContainerRef{
+		{Pod: "p1", Container: "web", Reason: "CrashLoopBackOff"},
+		{Pod: "p2", Reason: "Evicted"},
+	})
+	assert.Equal(t, "容器 web 失败: CrashLoopBackOff; pod p2: Evicted", got)
+}
+
+func TestToDomainFailures(t *testing.T) {
+	got := toDomainFailures([]failedContainerRef{{Pod: "p", Container: "web", Reason: "Error", Message: "m"}}, "Deployment", "dep")
+	if assert.Len(t, got, 1) {
+		assert.Equal(t, "Deployment", got[0].Kind)
+		assert.Equal(t, "dep", got[0].Workload)
+		assert.Equal(t, "p", got[0].Pod)
+		assert.Equal(t, "web", got[0].Container)
+		assert.Equal(t, "Error", got[0].Reason)
+		assert.Equal(t, "m", got[0].Message)
+	}
+}
+
+// ---------- collectWorkloadOldPods（STS/DS 旧副本分类） ----------
+
+// fakeStsK8sRepo 是 collectWorkloadOldPods 的 K8sRepo 替身，只覆写 GetStatefulSet。
+type fakeStsK8sRepo struct {
+	K8sRepo
+	sts *appsv1.StatefulSet
+	err error
+}
+
+func (f *fakeStsK8sRepo) GetStatefulSet(namespace, name string) (*appsv1.StatefulSet, error) {
+	return f.sts, f.err
+}
+
+func TestCollectWorkloadOldPods_StatefulSet(t *testing.T) {
+	pods := []*corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "sts-new", Namespace: "ns", Labels: map[string]string{appsv1.ControllerRevisionHashLabelKey: "rev2"}, OwnerReferences: []metav1.OwnerReference{{Kind: "StatefulSet", Name: "sts", UID: "u"}}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "sts-old", Namespace: "ns", Labels: map[string]string{appsv1.ControllerRevisionHashLabelKey: "rev1"}, OwnerReferences: []metav1.OwnerReference{{Kind: "StatefulSet", Name: "sts", UID: "u"}}}},
+	}
+	k := &fakeStsK8sRepo{sts: newStsForTest(1, 1, 2, "rev2")}
+	got := collectWorkloadOldPods(k, pods)
+	if assert.Len(t, got, 1) {
+		assert.Contains(t, got, "sts-old")
+	}
+}
+
+func TestCollectWorkloadOldPods_StatefulSet_ReadFail(t *testing.T) {
+	pods := []*corev1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: "sts-pod", Namespace: "ns", Labels: map[string]string{appsv1.ControllerRevisionHashLabelKey: "rev1"}, OwnerReferences: []metav1.OwnerReference{{Kind: "StatefulSet", Name: "sts"}}}}}
+	got := collectWorkloadOldPods(&fakeStsK8sRepo{err: errors.New("boom")}, pods)
+	assert.Empty(t, got)
+}
+
+func TestCollectWorkloadOldPods_StatefulSet_NoUpdateRevision(t *testing.T) {
+	pods := []*corev1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: "sts-pod", Namespace: "ns", Labels: map[string]string{appsv1.ControllerRevisionHashLabelKey: "rev1"}, OwnerReferences: []metav1.OwnerReference{{Kind: "StatefulSet", Name: "sts"}}}}}
+	got := collectWorkloadOldPods(&fakeStsK8sRepo{sts: newStsForTest(1, 1, 1, "")}, pods)
+	assert.Empty(t, got)
+}
+
+func TestCollectWorkloadOldPods_DaemonSet(t *testing.T) {
+	now := time.Now()
+	pods := []*corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "ds-new", Namespace: "ns", CreationTimestamp: metav1.Time{Time: now}, Labels: map[string]string{appsv1.ControllerRevisionHashLabelKey: "hash-new"}, OwnerReferences: []metav1.OwnerReference{{Kind: "DaemonSet", Name: "ds", UID: "u"}}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "ds-old", Namespace: "ns", CreationTimestamp: metav1.Time{Time: now.Add(-time.Hour)}, Labels: map[string]string{appsv1.ControllerRevisionHashLabelKey: "hash-old"}, OwnerReferences: []metav1.OwnerReference{{Kind: "DaemonSet", Name: "ds", UID: "u"}}}},
+	}
+	got := collectWorkloadOldPods(&fakeStsK8sRepo{}, pods)
+	if assert.Len(t, got, 1) {
+		assert.Contains(t, got, "ds-old")
+	}
+}
+
+func TestCollectWorkloadOldPods_NoStsDs(t *testing.T) {
+	pods := []*corev1.Pod{rsPodForTest("dep-pod", "rs", "")}
+	assert.Empty(t, collectWorkloadOldPods(&fakeStsK8sRepo{}, pods))
+}
+
+// ---------- CheckApplyStatus / judgeWorkloads 集成 ----------
+
+// fakeStatusK8sRepo 是 CheckApplyStatus 判定链路的 K8sRepo 替身：覆写 manifest 解析、
+// pod 列表与三类工作负载实时读取，并记录 GetPodLogs 收到的 Previous 标志。
+type fakeStatusK8sRepo struct {
+	K8sRepo
+	pods         []*corev1.Pod
+	listPodsErr  error
+	depWorkloads []*appsv1.Deployment
+	stsWorkloads []*appsv1.StatefulSet
+	dsWorkloads  []*appsv1.DaemonSet
+	deployments  map[string]*appsv1.Deployment
+	statefulSets map[string]*appsv1.StatefulSet
+	daemonSets   map[string]*appsv1.DaemonSet
+	replicaSets  []*appsv1.ReplicaSet
+	listRSErr    error
+	getDeployErr error
+	getStsErr    error
+	getDsErr     error
+	logs         map[string]string
+	logErr       error
+}
+
+func (f *fakeStatusK8sRepo) ListPodsBySelectors(namespace string, selectors []string) ([]*corev1.Pod, error) {
+	return f.pods, f.listPodsErr
+}
+
+func (f *fakeStatusK8sRepo) GetWorkloadsByManifest(manifests []string) ([]*appsv1.Deployment, []*appsv1.StatefulSet, []*appsv1.DaemonSet) {
+	return f.depWorkloads, f.stsWorkloads, f.dsWorkloads
+}
+
+func (f *fakeStatusK8sRepo) ListReplicaSets(namespace string) ([]*appsv1.ReplicaSet, error) {
+	return f.replicaSets, f.listRSErr
+}
+
+func (f *fakeStatusK8sRepo) GetReplicaSet(namespace, name string) (*appsv1.ReplicaSet, error) {
+	for _, rs := range f.replicaSets {
+		if rs.Name == name {
+			return rs, nil
+		}
+	}
+	return nil, errs.NotFound("replicaset not found")
+}
+
+func (f *fakeStatusK8sRepo) GetDeployment(namespace, name string) (*appsv1.Deployment, error) {
+	if f.getDeployErr != nil {
+		return nil, f.getDeployErr
+	}
+	if dep, ok := f.deployments[name]; ok {
+		return dep, nil
+	}
+	return nil, errs.NotFound("deployment not found")
+}
+
+func (f *fakeStatusK8sRepo) GetStatefulSet(namespace, name string) (*appsv1.StatefulSet, error) {
+	if f.getStsErr != nil {
+		return nil, f.getStsErr
+	}
+	if sts, ok := f.statefulSets[name]; ok {
+		return sts, nil
+	}
+	return nil, errs.NotFound("statefulset not found")
+}
+
+func (f *fakeStatusK8sRepo) GetDaemonSet(namespace, name string) (*appsv1.DaemonSet, error) {
+	if f.getDsErr != nil {
+		return nil, f.getDsErr
+	}
+	if ds, ok := f.daemonSets[name]; ok {
+		return ds, nil
+	}
+	return nil, errs.NotFound("daemonset not found")
+}
+
+func (f *fakeStatusK8sRepo) GetPodLogs(ctx context.Context, namespace, name string, opts *corev1.PodLogOptions) (string, error) {
+	if f.logErr != nil {
+		return "", f.logErr
+	}
+	return f.logs[name], nil
+}
+
+// fakeStatusProjectRepo 是 CheckApplyStatus 的 ProjectRepo 替身，只覆写 Show。
+type fakeStatusProjectRepo struct {
+	ProjectRepo
+	project *Project
+	err     error
+}
+
+func (f *fakeStatusProjectRepo) Show(ctx context.Context, id int) (*Project, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.project, nil
+}
+
+func newStatusProjectBiz(repo ProjectRepo, k8s K8sRepo) *projectBiz {
+	return &projectBiz{logger: mlog.NewForConfig(nil), projRepo: repo, k8sRepo: k8s}
+}
+
+func TestCheckApplyStatus_ShowError(t *testing.T) {
+	k := &fakeStatusK8sRepo{}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{err: errors.New("show down")}, k)
+	got, err := b.CheckApplyStatus(context.TODO(), 1)
+	assert.Nil(t, got)
+	assert.ErrorContains(t, err, "show down")
+}
+
+// TestCheckApplyStatus_NoWorkloads 覆盖无 Deployment/StatefulSet/DaemonSet 时返回 UNKNOWN。
+func TestCheckApplyStatus_NoWorkloads(t *testing.T) {
+	k := &fakeStatusK8sRepo{}
+	proj := &Project{Namespace: &Namespace{Name: "ns"}, PodSelectors: []string{"app=a"}}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{project: proj}, k)
+	got, err := b.CheckApplyStatus(context.TODO(), 1)
+	assert.NoError(t, err)
+	assert.Equal(t, types.Deploy_StatusUnknown, got.Status)
+	assert.Contains(t, got.Reason, "未发现")
+}
+
+// TestCheckApplyStatus_DeploymentNotFound 覆盖 Deployment 尚未创建 → Deploying。
+func TestCheckApplyStatus_DeploymentNotFound(t *testing.T) {
+	k := &fakeStatusK8sRepo{depWorkloads: []*appsv1.Deployment{{ObjectMeta: metav1.ObjectMeta{Name: "web"}}}}
+	proj := &Project{Namespace: &Namespace{Name: "ns"}, PodSelectors: []string{"app=a"}, Manifest: []string{"deploy"}}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{project: proj}, k)
+	got, err := b.CheckApplyStatus(context.TODO(), 1)
+	assert.NoError(t, err)
+	assert.Equal(t, types.Deploy_StatusDeploying, got.Status)
+	assert.Contains(t, got.Reason, "尚未创建")
+}
+
+func TestCheckApplyStatus_DeploymentError(t *testing.T) {
+	k := &fakeStatusK8sRepo{
+		depWorkloads: []*appsv1.Deployment{{ObjectMeta: metav1.ObjectMeta{Name: "web"}}},
+		getDeployErr: errors.New("boom"),
+	}
+	proj := &Project{Namespace: &Namespace{Name: "ns"}, PodSelectors: []string{"app=a"}, Manifest: []string{"deploy"}}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{project: proj}, k)
+	got, err := b.CheckApplyStatus(context.TODO(), 1)
+	assert.Nil(t, got)
+	assert.ErrorContains(t, err, "boom")
+}
+
+// TestCheckApplyStatus_BuildContainersError 覆盖 buildStateContainers 失败时 CheckApplyStatus 上抛。
+func TestCheckApplyStatus_BuildContainersError(t *testing.T) {
+	k := &fakeStatusK8sRepo{listPodsErr: errors.New("list down")}
+	proj := &Project{Namespace: &Namespace{Name: "ns"}, PodSelectors: []string{"app=a"}, Manifest: []string{"deploy"}}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{project: proj}, k)
+	got, err := b.CheckApplyStatus(context.TODO(), 1)
+	assert.Nil(t, got)
+	assert.ErrorContains(t, err, "list down")
+}
+
+// TestCheckApplyStatus_NoPodSelectors 覆盖项目无 PodSelectors 时 buildStateContainers
+// 提前返回（不触发 k8s 调用），判定仍走工作负载状态。
+func TestCheckApplyStatus_NoPodSelectors(t *testing.T) {
+	k := &fakeStatusK8sRepo{}
+	proj := &Project{Namespace: &Namespace{Name: "ns"}, Manifest: []string{"deploy"}}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{project: proj}, k)
+	got, err := b.CheckApplyStatus(context.TODO(), 1)
+	assert.NoError(t, err)
+	assert.Equal(t, types.Deploy_StatusUnknown, got.Status)
+}
+
+// TestCheckApplyStatus_FailedChain 覆盖整条失败链路：STS 最新版本 pod CrashLoopBackOff →
+// Failed + failures 明细 + fillFailureLogs 拉取日志尾部。
+func TestCheckApplyStatus_FailedChain(t *testing.T) {
+	sts := newStsForTest(1, 0, 1, "rev2")
+	sts.Name = "sts"
+	failPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "sts-pod", Namespace: "ns", Labels: map[string]string{appsv1.ControllerRevisionHashLabelKey: "rev2"}},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "web"}}},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+			Name:  "web",
+			State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+		}}},
+	}
+	k := &fakeStatusK8sRepo{
+		pods:         []*corev1.Pod{failPod},
+		stsWorkloads: []*appsv1.StatefulSet{sts},
+		statefulSets: map[string]*appsv1.StatefulSet{"sts": sts},
+		logs:         map[string]string{"sts-pod": "crash trace"},
+	}
+	proj := &Project{Namespace: &Namespace{Name: "ns"}, PodSelectors: []string{"app=a"}, Manifest: []string{"sts yaml"}}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{project: proj}, k)
+	got, err := b.CheckApplyStatus(context.TODO(), 1)
+	assert.NoError(t, err)
+	assert.Equal(t, types.Deploy_StatusFailed, got.Status)
+	assert.Contains(t, got.Reason, "CrashLoopBackOff")
+	if assert.Len(t, got.Failures, 1) {
+		assert.Equal(t, "StatefulSet", got.Failures[0].Kind)
+		assert.Equal(t, "sts", got.Failures[0].Workload)
+		assert.Equal(t, "sts-pod", got.Failures[0].Pod)
+		assert.Equal(t, "web", got.Failures[0].Container)
+		assert.Equal(t, "CrashLoopBackOff", got.Failures[0].Reason)
+		assert.Equal(t, "crash trace", got.Failures[0].Logs)
+	}
+}
+
+// ---------- judgeWorkloads 聚合 ----------
+
+func TestJudgeWorkloads_Deployed(t *testing.T) {
+	dep := newDepForTest(2, 2, 2)
+	dep.Name = "web"
+	k := &fakeStatusK8sRepo{
+		deployments: map[string]*appsv1.Deployment{"web": dep},
+		replicaSets: []*appsv1.ReplicaSet{newRSForTest("rs-new", "2", "dep")},
+		pods:        []*corev1.Pod{rsPodForTest("pod-new", "rs-new", "")},
+	}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{}, k)
+	st, reason, failures, err := b.judgeWorkloads(context.TODO(), "ns", []*appsv1.Deployment{dep}, nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, types.Deploy_StatusDeployed, st)
+	assert.Empty(t, reason)
+	assert.Empty(t, failures)
+}
+
+// TestJudgeWorkloads_FailedPriority 覆盖聚合优先级：一个失败 + 一个进行中 → 整体 Failed。
+func TestJudgeWorkloads_FailedPriority(t *testing.T) {
+	depFailed := newDepForTest(1, 0, 1)
+	depFailed.Name = "web"
+	depFailed.UID = "dep"
+	depDeploying := newDepForTest(1, 1, 2)
+	depDeploying.Name = "api"
+	depDeploying.UID = "other-dep"
+	k := &fakeStatusK8sRepo{
+		deployments: map[string]*appsv1.Deployment{"web": depFailed, "api": depDeploying},
+		replicaSets: []*appsv1.ReplicaSet{newRSForTest("rs-fail", "1", "dep")},
+		pods:        []*corev1.Pod{rsPodForTest("pod-fail", "rs-fail", "CrashLoopBackOff")},
+	}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{}, k)
+	st, reason, failures, err := b.judgeWorkloads(context.TODO(), "ns", []*appsv1.Deployment{depFailed, depDeploying}, nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, types.Deploy_StatusFailed, st)
+	assert.Contains(t, reason, "web")
+	assert.NotEmpty(t, failures)
+}
+
+// TestJudgeWorkloads_DeployingAggregation 覆盖全部进行中且无失败 → 整体 Deploying。
+func TestJudgeWorkloads_DeployingAggregation(t *testing.T) {
+	dep := newDepForTest(1, 1, 2)
+	dep.Name = "web"
+	k := &fakeStatusK8sRepo{
+		deployments: map[string]*appsv1.Deployment{"web": dep},
+		replicaSets: []*appsv1.ReplicaSet{newRSForTest("rs-new", "2", "dep")},
+		pods:        []*corev1.Pod{rsPodForTest("pod-new", "rs-new", "")},
+	}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{}, k)
+	st, reason, failures, err := b.judgeWorkloads(context.TODO(), "ns", []*appsv1.Deployment{dep}, nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, types.Deploy_StatusDeploying, st)
+	assert.Contains(t, reason, "滚动进行中")
+	assert.Empty(t, failures)
+}
+
+func TestJudgeWorkloads_ListReplicaSetsError(t *testing.T) {
+	dep := newDepForTest(1, 1, 1)
+	dep.Name = "web"
+	k := &fakeStatusK8sRepo{depWorkloads: []*appsv1.Deployment{dep}, listRSErr: errors.New("rs down")}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{}, k)
+	_, _, _, err := b.judgeWorkloads(context.TODO(), "ns", []*appsv1.Deployment{dep}, nil, nil)
+	assert.ErrorContains(t, err, "rs down")
+}
+
+func TestJudgeWorkloads_StatefulSetNotFound(t *testing.T) {
+	sts := newStsForTest(1, 1, 1, "rev2")
+	sts.Name = "sts"
+	k := &fakeStatusK8sRepo{stsWorkloads: []*appsv1.StatefulSet{sts}} // statefulSets 空 → 未创建
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{}, k)
+	st, reason, failures, err := b.judgeWorkloads(context.TODO(), "ns", nil, []*appsv1.StatefulSet{sts}, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, types.Deploy_StatusDeploying, st)
+	assert.Contains(t, reason, "尚未创建")
+	assert.Empty(t, failures)
+}
+
+func TestJudgeWorkloads_StatefulSetError(t *testing.T) {
+	sts := newStsForTest(1, 1, 1, "rev2")
+	sts.Name = "sts"
+	k := &fakeStatusK8sRepo{stsWorkloads: []*appsv1.StatefulSet{sts}, getStsErr: errors.New("boom")}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{}, k)
+	_, _, _, err := b.judgeWorkloads(context.TODO(), "ns", nil, []*appsv1.StatefulSet{sts}, nil)
+	assert.ErrorContains(t, err, "boom")
+}
+
+func TestJudgeWorkloads_DaemonSetNotFound(t *testing.T) {
+	ds := newDsForTest(2, 2, 2)
+	ds.Name = "ds"
+	k := &fakeStatusK8sRepo{dsWorkloads: []*appsv1.DaemonSet{ds}} // daemonSets 空 → 未创建
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{}, k)
+	st, reason, failures, err := b.judgeWorkloads(context.TODO(), "ns", nil, nil, []*appsv1.DaemonSet{ds})
+	assert.NoError(t, err)
+	assert.Equal(t, types.Deploy_StatusDeploying, st)
+	assert.Contains(t, reason, "尚未创建")
+	assert.Empty(t, failures)
+}
+
+func TestJudgeWorkloads_DaemonSetError(t *testing.T) {
+	ds := newDsForTest(2, 2, 2)
+	ds.Name = "ds"
+	k := &fakeStatusK8sRepo{dsWorkloads: []*appsv1.DaemonSet{ds}, getDsErr: errors.New("boom")}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{}, k)
+	_, _, _, err := b.judgeWorkloads(context.TODO(), "ns", nil, nil, []*appsv1.DaemonSet{ds})
+	assert.ErrorContains(t, err, "boom")
+}
+
+// TestPodsByWorkload_InvalidSelector 覆盖 selector 解析失败返回 nil 的防御分支
+// （manifest 中合法对象 selector 必可解析，此为对异常输入的兜底）。
+func TestPodsByWorkload_InvalidSelector(t *testing.T) {
+	k := &fakeStatusK8sRepo{}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{}, k)
+	sel := &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+		{Key: "k", Operator: metav1.LabelSelectorOperator("InvalidOp"), Values: []string{"v"}},
+	}}
+	assert.Nil(t, b.podsByWorkload("ns", sel))
+}
+
+// TestJudgeWorkloads_MixedWorkloads 覆盖三类工作负载混合：Deployment Deployed、
+// StatefulSet Deploying、DaemonSet Deployed → 整体 Deploying。
+func TestJudgeWorkloads_MixedWorkloads(t *testing.T) {
+	dep := newDepForTest(1, 1, 1)
+	dep.Name = "web"
+	sts := newStsForTest(1, 0, 2, "rev2")
+	sts.Name = "sts"
+	ds := newDsForTest(2, 2, 2)
+	ds.Name = "ds"
+	k := &fakeStatusK8sRepo{
+		deployments:  map[string]*appsv1.Deployment{"web": dep},
+		statefulSets: map[string]*appsv1.StatefulSet{"sts": sts},
+		daemonSets:   map[string]*appsv1.DaemonSet{"ds": ds},
+		replicaSets:  []*appsv1.ReplicaSet{newRSForTest("rs-new", "2", "dep")},
+		pods:         []*corev1.Pod{rsPodForTest("pod-new", "rs-new", "")},
+	}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{}, k)
+	st, reason, failures, err := b.judgeWorkloads(context.TODO(), "ns", []*appsv1.Deployment{dep}, []*appsv1.StatefulSet{sts}, []*appsv1.DaemonSet{ds})
+	assert.NoError(t, err)
+	assert.Equal(t, types.Deploy_StatusDeploying, st)
+	assert.Contains(t, reason, "sts")
+	assert.Empty(t, failures)
+}
+
+// ---------- fillFailureLogs ----------
+
+func TestFillFailureLogs_CrashLoopPrevious(t *testing.T) {
+	k := &fakeStatusK8sRepo{logs: map[string]string{"p": "  log line  \n"}}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{}, k)
+	failures := []*ContainerFailure{{Pod: "p", Container: "web", Reason: "CrashLoopBackOff"}}
+	b.fillFailureLogs(context.TODO(), "ns", failures)
+	assert.Equal(t, "log line", failures[0].Logs)
+}
+
+func TestFillFailureLogs_LogErrorSwallowed(t *testing.T) {
+	k := &fakeStatusK8sRepo{logErr: errors.New("no logs")}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{}, k)
+	failures := []*ContainerFailure{{Pod: "p", Container: "web", Reason: "ImagePullBackOff"}}
+	b.fillFailureLogs(context.TODO(), "ns", failures)
+	assert.Empty(t, failures[0].Logs)
+}
+
+func TestFillFailureLogs_SkipEmptyContainer(t *testing.T) {
+	k := &fakeStatusK8sRepo{logs: map[string]string{"p": "x"}}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{}, k)
+	failures := []*ContainerFailure{{Pod: "p", Reason: "Evicted"}}
+	b.fillFailureLogs(context.TODO(), "ns", failures)
+	assert.Empty(t, failures[0].Logs)
+}

--- a/internal/biz/k8s.go
+++ b/internal/biz/k8s.go
@@ -311,6 +311,17 @@ type K8sRepo interface {
 	ListPodsBySelectors(namespace string, selectors []string) ([]*corev1.Pod, error)
 	// GetReplicaSet 查询指定 ReplicaSet。
 	GetReplicaSet(namespace, name string) (*appsv1.ReplicaSet, error)
+	// ListReplicaSets 列出命名空间下全部 ReplicaSet（定位 Deployment 最新版本 pod 用）。
+	ListReplicaSets(namespace string) ([]*appsv1.ReplicaSet, error)
+	// GetDeployment 读取 Deployment 实时对象（部署后状态判定用）。
+	GetDeployment(namespace, name string) (*appsv1.Deployment, error)
+	// GetStatefulSet 读取 StatefulSet 实时对象（部署后状态判定用）。
+	GetStatefulSet(namespace, name string) (*appsv1.StatefulSet, error)
+	// GetDaemonSet 读取 DaemonSet 实时对象（部署后状态判定用）。
+	GetDaemonSet(namespace, name string) (*appsv1.DaemonSet, error)
+	// GetWorkloadsByManifest 从 manifest 解析滚动更新工作负载对象
+	// （Deployment/StatefulSet/DaemonSet 三组，用于确定本次部署的工作负载）。
+	GetWorkloadsByManifest(manifests []string) (deployments []*appsv1.Deployment, statefulSets []*appsv1.StatefulSet, daemonSets []*appsv1.DaemonSet)
 	// ListServices 列出命名空间下全部 Service。
 	ListServices(namespace string) ([]*corev1.Service, error)
 	// ListIngresses 列出命名空间下全部 Ingress。

--- a/internal/biz/mock_biz.go
+++ b/internal/biz/mock_biz.go
@@ -523,6 +523,21 @@ func (m *MockProjectBiz) EXPECT() *MockProjectBizMockRecorder {
 	return m.recorder
 }
 
+// CheckApplyStatus mocks base method.
+func (m *MockProjectBiz) CheckApplyStatus(arg0 context.Context, arg1 int) (*ApplyStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckApplyStatus", arg0, arg1)
+	ret0, _ := ret[0].(*ApplyStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckApplyStatus indicates an expected call of CheckApplyStatus.
+func (mr *MockProjectBizMockRecorder) CheckApplyStatus(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckApplyStatus", reflect.TypeOf((*MockProjectBiz)(nil).CheckApplyStatus), arg0, arg1)
+}
+
 // Create mocks base method.
 func (m *MockProjectBiz) Create(arg0 context.Context, arg1 *CreateProjectInput) (*Project, error) {
 	m.ctrl.T.Helper()

--- a/internal/biz/pod.go
+++ b/internal/biz/pod.go
@@ -76,7 +76,8 @@ func isContainerReady(pod *corev1.Pod, containerName string) bool {
 }
 
 // buildStateContainers 从项目的 PodSelectors 出发推导出活跃容器的状态列表。
-// 领域逻辑：通过 ReplicaSet 的 deployment revision 注解识别滚动发布中的旧版本副本，
+// 领域逻辑：Deployment 通过 ReplicaSet 的 deployment revision 注解识别滚动发布中的
+// 旧版本副本；StatefulSet/DaemonSet 按 controller-revision-hash 识别旧版本副本；
 // 并过滤掉标注了 IgnoreContainerNames 的 sidecar 容器。
 func buildStateContainers(ctx context.Context, k8sRepo K8sRepo, proj *Project) ([]*types.StateContainer, error) {
 	if len(proj.PodSelectors) == 0 {
@@ -97,7 +98,6 @@ func buildStateContainers(ctx context.Context, k8sRepo K8sRepo, proj *Project) (
 	var objectMap = make(map[string]runtime.Object)
 	var oldReplicaMap = make(map[string]struct{})
 
-	// TODO: 兼容 sts pod
 	for _, pod := range list {
 		for _, reference := range pod.OwnerReferences {
 			if reference.Kind == "ReplicaSet" {
@@ -147,9 +147,20 @@ func buildStateContainers(ctx context.Context, k8sRepo K8sRepo, proj *Project) (
 		}
 	}
 
+	// 收集 StatefulSet/DaemonSet 的旧版本 pod：其 pod 无 ReplicaSet 属主，无法走
+	// 上面的 revision 判定，需按 controller-revision-hash 与状态值单独识别。
+	var podList []*corev1.Pod
+	for _, pod := range list {
+		podList = append(podList, pod)
+	}
+	oldPodNames := collectWorkloadOldPods(k8sRepo, podList)
+
 	var newList SortStatePod
 	for _, pod := range list {
 		var isOld bool
+		if _, ok := oldPodNames[pod.Name]; ok {
+			isOld = true
+		}
 		for _, reference := range pod.OwnerReferences {
 			if _, ok := oldReplicaMap[string(reference.UID)]; ok {
 				isOld = true
@@ -198,4 +209,50 @@ func buildStateContainers(ctx context.Context, k8sRepo K8sRepo, proj *Project) (
 	}
 
 	return containerList, nil
+}
+
+// collectWorkloadOldPods 识别 StatefulSet/DaemonSet 的旧版本 pod 名集合。
+// StatefulSet：controller-revision-hash != status.updateRevision 视为旧副本；
+// DaemonSet：状态无 revision 字段，按 controller-revision-hash 分组，取创建时间
+// 最新的一组为新版本，其余视为旧副本。读取失败或未滚动的负载不标记旧（保守不误标）。
+func collectWorkloadOldPods(k8sRepo K8sRepo, pods []*corev1.Pod) map[string]struct{} {
+	oldPods := make(map[string]struct{})
+	stsGroups := make(map[string][]*corev1.Pod)
+	dsGroups := make(map[string][]*corev1.Pod)
+	for _, pod := range pods {
+		for _, ref := range pod.OwnerReferences {
+			switch ref.Kind {
+			case "StatefulSet":
+				stsGroups[pod.Namespace+"/"+ref.Name] = append(stsGroups[pod.Namespace+"/"+ref.Name], pod)
+			case "DaemonSet":
+				dsGroups[pod.Namespace+"/"+ref.Name] = append(dsGroups[pod.Namespace+"/"+ref.Name], pod)
+			}
+		}
+	}
+	for key, group := range stsGroups {
+		parts := strings.SplitN(key, "/", 2)
+		sts, err := k8sRepo.GetStatefulSet(parts[0], parts[1])
+		if err != nil || sts.Status.UpdateRevision == "" {
+			continue
+		}
+		for _, pod := range group {
+			if pod.Labels[appsv1.ControllerRevisionHashLabelKey] != sts.Status.UpdateRevision {
+				oldPods[pod.Name] = struct{}{}
+			}
+		}
+	}
+	for _, group := range dsGroups {
+		// daemonSetNewPods 对非空 group 恒返回非空（无 hash 时兜底返回全部），无空集分支。
+		newPods := daemonSetNewPods(group)
+		newNames := make(map[string]struct{}, len(newPods))
+		for _, pod := range newPods {
+			newNames[pod.Name] = struct{}{}
+		}
+		for _, pod := range group {
+			if _, ok := newNames[pod.Name]; !ok {
+				oldPods[pod.Name] = struct{}{}
+			}
+		}
+	}
+	return oldPods
 }

--- a/internal/biz/pod_test.go
+++ b/internal/biz/pod_test.go
@@ -97,13 +97,16 @@ func TestSortStatePod_Less(t *testing.T) {
 	assert.True(t, pods.Less(0, 1))
 }
 
-// fakePodK8sRepo 是 buildStateContainers 的 K8sRepo 替身，只覆写容器拓扑推导用到的两个原语。
+// fakePodK8sRepo 是 buildStateContainers 的 K8sRepo 替身，覆写容器拓扑推导用到的
+// ListPodsBySelectors/GetReplicaSet/GetStatefulSet 三个原语（collectWorkloadOldPods 分类用）。
 type fakePodK8sRepo struct {
 	K8sRepo
 	pods             []*corev1.Pod
 	listPodsErr      error
 	replicaSets      map[string]*appsv1.ReplicaSet
 	getReplicaSetErr error
+	sts              *appsv1.StatefulSet
+	stsErr           error
 }
 
 func (f *fakePodK8sRepo) ListPodsBySelectors(namespace string, selectors []string) ([]*corev1.Pod, error) {
@@ -115,6 +118,13 @@ func (f *fakePodK8sRepo) GetReplicaSet(namespace, name string) (*appsv1.ReplicaS
 		return nil, f.getReplicaSetErr
 	}
 	return f.replicaSets[name], nil
+}
+
+func (f *fakePodK8sRepo) GetStatefulSet(namespace, name string) (*appsv1.StatefulSet, error) {
+	if f.stsErr != nil {
+		return nil, f.stsErr
+	}
+	return f.sts, nil
 }
 
 func TestBuildStateContainers_EmptySelectors(t *testing.T) {
@@ -346,5 +356,35 @@ func TestBuildStateContainers_RevisionCompareBothBranches(t *testing.T) {
 			assert.False(t, got[0].IsOld)
 			assert.True(t, got[1].IsOld)
 		}
+	}
+}
+
+// TestBuildStateContainers_StsOldPod 覆盖 StatefulSet 旧副本经 collectWorkloadOldPods
+// 分类后标记 IsOld：pod 的 controller-revision-hash 与 status.updateRevision 不一致即旧副本，
+// 且不依赖 ReplicaSet 属主路径（此路径此前导致 STS/DS 的 is_old 误判）。
+func TestBuildStateContainers_StsOldPod(t *testing.T) {
+	podOld := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "sts-old",
+			Namespace:       "ns",
+			Labels:          map[string]string{appsv1.ControllerRevisionHashLabelKey: "rev1"},
+			OwnerReferences: []metav1.OwnerReference{{Kind: "StatefulSet", Name: "sts", UID: "sts-uid"}},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "web"}}},
+		Status: corev1.PodStatus{
+			Phase:             corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "web", Ready: true}},
+		},
+	}
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "sts", Namespace: "ns", UID: "sts-uid"},
+		Status:     appsv1.StatefulSetStatus{UpdateRevision: "rev2"},
+	}
+	k := &fakePodK8sRepo{pods: []*corev1.Pod{podOld}, sts: sts}
+	got, err := buildStateContainers(context.TODO(), k, &Project{Namespace: &Namespace{Name: "ns"}, PodSelectors: []string{"app=a"}})
+	assert.NoError(t, err)
+	if assert.Len(t, got, 1) {
+		assert.Equal(t, "sts-old", got[0].Pod)
+		assert.True(t, got[0].IsOld)
 	}
 }

--- a/internal/biz/project.go
+++ b/internal/biz/project.go
@@ -14,6 +14,8 @@ import (
 type ProjectBiz interface {
 	// GetAllActiveContainers 返回项目当前活跃容器状态。
 	GetAllActiveContainers(ctx context.Context, id int) ([]*types.StateContainer, error)
+	// CheckApplyStatus 判定项目最近一次部署后新版本容器是否正常运行。
+	CheckApplyStatus(ctx context.Context, id int) (*ApplyStatus, error)
 	// GetProjectEndpointsInNamespace 汇总命名空间内项目的服务端点。
 	GetProjectEndpointsInNamespace(ctx context.Context, namespace string, projectIDs ...int) ([]*types.ServiceEndpoint, error)
 	// List 分页列出项目。

--- a/internal/data/data.go
+++ b/internal/data/data.go
@@ -342,6 +342,9 @@ func (data *dataImpl) InitK8s(ch <-chan struct{}) (err error) {
 		svcLister := inf.Core().V1().Services().Lister()
 		ingLister := inf.Networking().V1().Ingresses().Lister()
 		rsLister := inf.Apps().V1().ReplicaSets().Lister()
+		deployLister := inf.Apps().V1().Deployments().Lister()
+		stsLister := inf.Apps().V1().StatefulSets().Lister()
+		dsLister := inf.Apps().V1().DaemonSets().Lister()
 		podInf := inf.Core().V1().Pods().Informer()
 		podLister := inf.Core().V1().Pods().Lister()
 		secretInf := inf.Core().V1().Secrets().Informer()
@@ -389,6 +392,9 @@ func (data *dataImpl) InitK8s(ch <-chan struct{}) (err error) {
 			SecretInformer:      secretInf,
 			SecretLister:        secretLister,
 			ReplicaSetLister:    rsLister,
+			DeploymentLister:    deployLister,
+			StatefulSetLister:   stsLister,
+			DaemonSetLister:     dsLister,
 			ServiceLister:       svcLister,
 			IngressLister:       ingLister,
 			eventFanOut:         eventFanOutObj,

--- a/internal/data/k8s.go
+++ b/internal/data/k8s.go
@@ -998,6 +998,50 @@ func (repo *k8sRepo) GetReplicaSet(namespace, name string) (*appsv1.ReplicaSet, 
 	return rs, errs.Wrap(err, "get replica set")
 }
 
+// ListReplicaSets 经 informer lister 列出命名空间下全部 ReplicaSet
+// （部署后状态判定用：定位 Deployment 下 revision 最大的最新 ReplicaSet）。
+func (repo *k8sRepo) ListReplicaSets(namespace string) ([]*appsv1.ReplicaSet, error) {
+	list, err := repo.data.K8s().ReplicaSetLister.ReplicaSets(namespace).List(labels.Everything())
+	return list, errs.Wrap(err, "list replica sets")
+}
+
+// GetDeployment 经 informer lister 读取 Deployment（部署后状态判定用）。
+func (repo *k8sRepo) GetDeployment(namespace, name string) (*appsv1.Deployment, error) {
+	dep, err := repo.data.K8s().DeploymentLister.Deployments(namespace).Get(name)
+	return dep, errs.Wrap(err, "get deployment")
+}
+
+// GetStatefulSet 经 informer lister 读取 StatefulSet（部署后状态判定用）。
+func (repo *k8sRepo) GetStatefulSet(namespace, name string) (*appsv1.StatefulSet, error) {
+	sts, err := repo.data.K8s().StatefulSetLister.StatefulSets(namespace).Get(name)
+	return sts, errs.Wrap(err, "get statefulset")
+}
+
+// GetDaemonSet 经 informer lister 读取 DaemonSet（部署后状态判定用）。
+func (repo *k8sRepo) GetDaemonSet(namespace, name string) (*appsv1.DaemonSet, error) {
+	ds, err := repo.data.K8s().DaemonSetLister.DaemonSets(namespace).Get(name)
+	return ds, errs.Wrap(err, "get daemonset")
+}
+
+// GetWorkloadsByManifest 从 manifest 解析滚动更新类工作负载对象：
+// 返回 Deployment/StatefulSet/DaemonSet 三组对象，其余资源或无法解码的片段跳过。
+// 供部署后状态判定确定"本次部署了哪些工作负载"。
+func (repo *k8sRepo) GetWorkloadsByManifest(manifests []string) (deployments []*appsv1.Deployment, statefulSets []*appsv1.StatefulSet, daemonSets []*appsv1.DaemonSet) {
+	info, _ := runtime.SerializerInfoForMediaType(scheme.Codecs.SupportedMediaTypes(), runtime.ContentTypeYAML)
+	for _, f := range manifests {
+		obj, _, _ := info.Serializer.Decode([]byte(f), nil, nil)
+		switch a := obj.(type) {
+		case *appsv1.Deployment:
+			deployments = append(deployments, a)
+		case *appsv1.StatefulSet:
+			statefulSets = append(statefulSets, a)
+		case *appsv1.DaemonSet:
+			daemonSets = append(daemonSets, a)
+		}
+	}
+	return deployments, statefulSets, daemonSets
+}
+
 // ListServices 列出命名空间下全部 Service。
 func (repo *k8sRepo) ListServices(namespace string) ([]*corev1.Service, error) {
 	services, err := repo.data.K8s().ServiceLister.Services(namespace).List(labels.Everything())

--- a/internal/data/k8s_client.go
+++ b/internal/data/k8s_client.go
@@ -36,9 +36,12 @@ type K8sClient struct {
 	SecretInformer cache.SharedIndexInformer
 	SecretLister   v1.SecretLister
 
-	ReplicaSetLister appsv1.ReplicaSetLister
-	ServiceLister    v1.ServiceLister
-	IngressLister    networkingv1.IngressLister
+	ReplicaSetLister  appsv1.ReplicaSetLister
+	DeploymentLister  appsv1.DeploymentLister
+	StatefulSetLister appsv1.StatefulSetLister
+	DaemonSetLister   appsv1.DaemonSetLister
+	ServiceLister     v1.ServiceLister
+	IngressLister     networkingv1.IngressLister
 
 	eventFanOut fanOutInterface[*eventsv1.Event]
 	podFanOut   fanOutInterface[*corev1.Pod]

--- a/internal/data/k8s_test.go
+++ b/internal/data/k8s_test.go
@@ -29,6 +29,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -36,6 +37,7 @@ import (
 	labels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	appsv1lister "k8s.io/client-go/listers/apps/v1"
 	corev1lister "k8s.io/client-go/listers/core/v1"
 	eventsv1lister "k8s.io/client-go/listers/events/v1"
 	restclient "k8s.io/client-go/rest"
@@ -2294,3 +2296,213 @@ func TestK8sRepo_CopyFileToPod_UpdateError(t *testing.T) {
 // `_, _ =` 丢弃，随后硬编码一个恒返回 200 "fake logs" 的 HTTP client 供 Stream() 用。
 // 无论 reactor 注入错误还是内容都被吞掉：错误分支拿不到 err，
 // 正常路径读循环拿到默认 "fake logs" 且 nil-deref panic，单测无法稳定驱动。
+
+// newWorkloadIndexer 构造一个以命名空间索引的 shared indexer，供 workload lister 构造用。
+func newWorkloadIndexer() cache.Indexer {
+	return cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+}
+
+// NewDeploymentLister 构造带指定对象的 Deployment lister。
+func NewDeploymentLister(deps ...*appsv1.Deployment) appsv1lister.DeploymentLister {
+	idxer := newWorkloadIndexer()
+	for _, d := range deps {
+		_ = idxer.Add(d)
+	}
+	return appsv1lister.NewDeploymentLister(idxer)
+}
+
+// NewStatefulSetLister 构造带指定对象的 StatefulSet lister。
+func NewStatefulSetLister(stsList ...*appsv1.StatefulSet) appsv1lister.StatefulSetLister {
+	idxer := newWorkloadIndexer()
+	for _, s := range stsList {
+		_ = idxer.Add(s)
+	}
+	return appsv1lister.NewStatefulSetLister(idxer)
+}
+
+// NewDaemonSetLister 构造带指定对象的 DaemonSet lister。
+func NewDaemonSetLister(dss ...*appsv1.DaemonSet) appsv1lister.DaemonSetLister {
+	idxer := newWorkloadIndexer()
+	for _, d := range dss {
+		_ = idxer.Add(d)
+	}
+	return appsv1lister.NewDaemonSetLister(idxer)
+}
+
+// errNamespaceLister 是 List/Get 恒报错的命名空间级 workload lister 替身。
+type errNamespaceLister[T any] struct{}
+
+func (errNamespaceLister[T]) List(_ labels.Selector) ([]*T, error) {
+	return nil, errors.New("list boom")
+}
+func (errNamespaceLister[T]) Get(string) (*T, error) { return nil, errors.New("get boom") }
+
+// errDeploymentLister 是 Deployment lister 替身，Deployments 返回恒报错的命名空间级 lister。
+type errDeploymentLister struct{}
+
+func (errDeploymentLister) List(labels.Selector) ([]*appsv1.Deployment, error) {
+	return nil, errors.New("boom")
+}
+func (errDeploymentLister) Deployments(string) appsv1lister.DeploymentNamespaceLister {
+	return errNamespaceLister[appsv1.Deployment]{}
+}
+
+// errStatefulSetLister 是 StatefulSet lister 替身，StatefulSets 返回恒报错的命名空间级 lister。
+type errStatefulSetLister struct{}
+
+func (errStatefulSetLister) List(labels.Selector) ([]*appsv1.StatefulSet, error) {
+	return nil, errors.New("boom")
+}
+func (errStatefulSetLister) StatefulSets(string) appsv1lister.StatefulSetNamespaceLister {
+	return errNamespaceLister[appsv1.StatefulSet]{}
+}
+func (errStatefulSetLister) GetPodStatefulSets(*corev1.Pod) ([]*appsv1.StatefulSet, error) {
+	return nil, errors.New("boom")
+}
+
+// errDaemonSetLister 是 DaemonSet lister 替身，DaemonSets 返回恒报错的命名空间级 lister。
+type errDaemonSetLister struct{}
+
+func (errDaemonSetLister) List(labels.Selector) ([]*appsv1.DaemonSet, error) {
+	return nil, errors.New("boom")
+}
+func (errDaemonSetLister) DaemonSets(string) appsv1lister.DaemonSetNamespaceLister {
+	return errNamespaceLister[appsv1.DaemonSet]{}
+}
+func (errDaemonSetLister) GetPodDaemonSets(*corev1.Pod) ([]*appsv1.DaemonSet, error) {
+	return nil, errors.New("boom")
+}
+func (errDaemonSetLister) GetHistoryDaemonSets(*appsv1.ControllerRevision) ([]*appsv1.DaemonSet, error) {
+	return nil, errors.New("boom")
+}
+
+// errReplicaSetLister 是 ReplicaSet lister 替身，ReplicaSets 返回恒报错的命名空间级 lister。
+type errReplicaSetLister struct{}
+
+func (errReplicaSetLister) List(labels.Selector) ([]*appsv1.ReplicaSet, error) {
+	return nil, errors.New("boom")
+}
+func (errReplicaSetLister) ReplicaSets(string) appsv1lister.ReplicaSetNamespaceLister {
+	return errNamespaceLister[appsv1.ReplicaSet]{}
+}
+func (errReplicaSetLister) GetPodReplicaSets(*corev1.Pod) ([]*appsv1.ReplicaSet, error) {
+	return nil, errors.New("boom")
+}
+
+// newK8sRepoWithClient 构造包住指定 K8sClient 的 k8sRepo，供 lister 读取方法测试用。
+func newK8sRepoWithClient(mockData *MockDataStore, c *K8sClient) *k8sRepo {
+	mockData.EXPECT().K8s().Return(c).AnyTimes()
+	return &k8sRepo{logger: mlog.NewForConfig(nil), data: mockData}
+}
+
+func TestK8sRepo_ListReplicaSets(t *testing.T) {
+	m := gomock.NewController(t)
+	defer m.Finish()
+	rs := &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{Name: "web-abc", Namespace: "ns"}}
+	kr := newK8sRepoWithClient(NewMockDataStore(m), &K8sClient{ReplicaSetLister: NewRsLister(rs)})
+
+	got, err := kr.ListReplicaSets("ns")
+	assert.NoError(t, err)
+	if assert.Len(t, got, 1) {
+		assert.Equal(t, "web-abc", got[0].Name)
+	}
+
+	// informer List 失败 → errs.Wrap 上抛。
+	krErr := newK8sRepoWithClient(NewMockDataStore(m), &K8sClient{ReplicaSetLister: errReplicaSetLister{}})
+	_, err = krErr.ListReplicaSets("ns")
+	assert.ErrorContains(t, err, "list replica sets")
+}
+
+func TestK8sRepo_GetDeployment(t *testing.T) {
+	m := gomock.NewController(t)
+	defer m.Finish()
+	dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "ns"}}
+	kr := newK8sRepoWithClient(NewMockDataStore(m), &K8sClient{DeploymentLister: NewDeploymentLister(dep)})
+
+	got, err := kr.GetDeployment("ns", "web")
+	assert.NoError(t, err)
+	assert.Equal(t, "web", got.Name)
+
+	// informer Get 失败（not found）→ errs.Wrap 上抛。
+	krErr := newK8sRepoWithClient(NewMockDataStore(m), &K8sClient{DeploymentLister: errDeploymentLister{}})
+	_, err = krErr.GetDeployment("ns", "web")
+	assert.ErrorContains(t, err, "get deployment")
+}
+
+func TestK8sRepo_GetStatefulSet(t *testing.T) {
+	m := gomock.NewController(t)
+	defer m.Finish()
+	sts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "ns"}}
+	kr := newK8sRepoWithClient(NewMockDataStore(m), &K8sClient{StatefulSetLister: NewStatefulSetLister(sts)})
+
+	got, err := kr.GetStatefulSet("ns", "db")
+	assert.NoError(t, err)
+	assert.Equal(t, "db", got.Name)
+
+	krErr := newK8sRepoWithClient(NewMockDataStore(m), &K8sClient{StatefulSetLister: errStatefulSetLister{}})
+	_, err = krErr.GetStatefulSet("ns", "db")
+	assert.ErrorContains(t, err, "get statefulset")
+}
+
+func TestK8sRepo_GetDaemonSet(t *testing.T) {
+	m := gomock.NewController(t)
+	defer m.Finish()
+	ds := &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "ns"}}
+	kr := newK8sRepoWithClient(NewMockDataStore(m), &K8sClient{DaemonSetLister: NewDaemonSetLister(ds)})
+
+	got, err := kr.GetDaemonSet("ns", "agent")
+	assert.NoError(t, err)
+	assert.Equal(t, "agent", got.Name)
+
+	krErr := newK8sRepoWithClient(NewMockDataStore(m), &K8sClient{DaemonSetLister: errDaemonSetLister{}})
+	_, err = krErr.GetDaemonSet("ns", "agent")
+	assert.ErrorContains(t, err, "get daemonset")
+}
+
+// TestK8sRepo_GetWorkloadsByManifest 覆盖从 manifest 解析三类工作负载：Deployment/STS/DS
+// 各识别一个，Service/无法解码片段跳过。
+func TestK8sRepo_GetWorkloadsByManifest(t *testing.T) {
+	kr := &k8sRepo{logger: mlog.NewForConfig(nil)}
+	deployments, statefulSets, daemonSets := kr.GetWorkloadsByManifest([]string{
+		dedent.Dedent(`
+			apiVersion: apps/v1
+			kind: Deployment
+			metadata:
+			  name: web
+			  namespace: ns
+		`),
+		dedent.Dedent(`
+			apiVersion: apps/v1
+			kind: StatefulSet
+			metadata:
+			  name: db
+			  namespace: ns
+		`),
+		dedent.Dedent(`
+			apiVersion: apps/v1
+			kind: DaemonSet
+			metadata:
+			  name: agent
+			  namespace: ns
+		`),
+		// Service 不属于滚动更新工作负载，跳过。
+		dedent.Dedent(`
+			apiVersion: v1
+			kind: Service
+			metadata:
+			  name: svc
+			  namespace: ns
+		`),
+		// 无法解码的片段（空对象）跳过。
+		"",
+	})
+	if assert.Len(t, deployments, 1) {
+		assert.Equal(t, "web", deployments[0].Name)
+	}
+	if assert.Len(t, statefulSets, 1) {
+		assert.Equal(t, "db", statefulSets[0].Name)
+	}
+	if assert.Len(t, daemonSets, 1) {
+		assert.Equal(t, "agent", daemonSets[0].Name)
+	}
+}

--- a/internal/data/mock_repo.go
+++ b/internal/data/mock_repo.go
@@ -912,6 +912,36 @@ func (mr *MockK8sRepoMockRecorder) GetCpuAndMemoryQuantity(arg0 any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCpuAndMemoryQuantity", reflect.TypeOf((*MockK8sRepo)(nil).GetCpuAndMemoryQuantity), arg0)
 }
 
+// GetDaemonSet mocks base method.
+func (m *MockK8sRepo) GetDaemonSet(arg0, arg1 string) (*v1.DaemonSet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDaemonSet", arg0, arg1)
+	ret0, _ := ret[0].(*v1.DaemonSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDaemonSet indicates an expected call of GetDaemonSet.
+func (mr *MockK8sRepoMockRecorder) GetDaemonSet(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDaemonSet", reflect.TypeOf((*MockK8sRepo)(nil).GetDaemonSet), arg0, arg1)
+}
+
+// GetDeployment mocks base method.
+func (m *MockK8sRepo) GetDeployment(arg0, arg1 string) (*v1.Deployment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeployment", arg0, arg1)
+	ret0, _ := ret[0].(*v1.Deployment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeployment indicates an expected call of GetDeployment.
+func (mr *MockK8sRepoMockRecorder) GetDeployment(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeployment", reflect.TypeOf((*MockK8sRepo)(nil).GetDeployment), arg0, arg1)
+}
+
 // GetNamespace mocks base method.
 func (m *MockK8sRepo) GetNamespace(arg0 context.Context, arg1 string) (*v10.Namespace, error) {
 	m.ctrl.T.Helper()
@@ -1016,6 +1046,37 @@ func (mr *MockK8sRepoMockRecorder) GetSecret(arg0, arg1, arg2 any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockK8sRepo)(nil).GetSecret), arg0, arg1, arg2)
 }
 
+// GetStatefulSet mocks base method.
+func (m *MockK8sRepo) GetStatefulSet(arg0, arg1 string) (*v1.StatefulSet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStatefulSet", arg0, arg1)
+	ret0, _ := ret[0].(*v1.StatefulSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStatefulSet indicates an expected call of GetStatefulSet.
+func (mr *MockK8sRepoMockRecorder) GetStatefulSet(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStatefulSet", reflect.TypeOf((*MockK8sRepo)(nil).GetStatefulSet), arg0, arg1)
+}
+
+// GetWorkloadsByManifest mocks base method.
+func (m *MockK8sRepo) GetWorkloadsByManifest(arg0 []string) ([]*v1.Deployment, []*v1.StatefulSet, []*v1.DaemonSet) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkloadsByManifest", arg0)
+	ret0, _ := ret[0].([]*v1.Deployment)
+	ret1, _ := ret[1].([]*v1.StatefulSet)
+	ret2, _ := ret[2].([]*v1.DaemonSet)
+	return ret0, ret1, ret2
+}
+
+// GetWorkloadsByManifest indicates an expected call of GetWorkloadsByManifest.
+func (mr *MockK8sRepoMockRecorder) GetWorkloadsByManifest(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkloadsByManifest", reflect.TypeOf((*MockK8sRepo)(nil).GetWorkloadsByManifest), arg0)
+}
+
 // IsPodRunning mocks base method.
 func (m *MockK8sRepo) IsPodRunning(arg0, arg1 string) (bool, string) {
 	m.ctrl.T.Helper()
@@ -1089,6 +1150,21 @@ func (m *MockK8sRepo) ListPodsBySelectors(arg0 string, arg1 []string) ([]*v10.Po
 func (mr *MockK8sRepoMockRecorder) ListPodsBySelectors(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPodsBySelectors", reflect.TypeOf((*MockK8sRepo)(nil).ListPodsBySelectors), arg0, arg1)
+}
+
+// ListReplicaSets mocks base method.
+func (m *MockK8sRepo) ListReplicaSets(arg0 string) ([]*v1.ReplicaSet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListReplicaSets", arg0)
+	ret0, _ := ret[0].([]*v1.ReplicaSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListReplicaSets indicates an expected call of ListReplicaSets.
+func (mr *MockK8sRepoMockRecorder) ListReplicaSets(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListReplicaSets", reflect.TypeOf((*MockK8sRepo)(nil).ListReplicaSets), arg0)
 }
 
 // ListServices mocks base method.

--- a/internal/services/project.go
+++ b/internal/services/project.go
@@ -283,6 +283,41 @@ func (p *projectSvc) AllContainers(ctx context.Context, request *project.AllCont
 	return &project.AllContainersResponse{Items: pods}, nil
 }
 
+// CheckApplyStatus 判定项目最近一次部署后新版本容器是否正常运行（非原子 WebApply 用），
+// 响应前做项目级访问控制，聚合状态/原因/容器明细/失败诊断一并返回。
+func (p *projectSvc) CheckApplyStatus(ctx context.Context, request *project.CheckApplyStatusRequest) (*project.CheckApplyStatusResponse, error) {
+	if _, err := p.accessBiz.RequireProjectAccess(ctx, int(request.Id)); err != nil {
+		return nil, logError(ctx, p.logger, err)
+	}
+	status, err := p.projBiz.CheckApplyStatus(ctx, int(request.Id))
+	if err != nil {
+		return nil, logError(ctx, p.logger, err)
+	}
+	return &project.CheckApplyStatusResponse{
+		Status:     status.Status,
+		Reason:     status.Reason,
+		Containers: status.Containers,
+		Failures:   mapDomainFailures(status.Failures),
+	}, nil
+}
+
+// mapDomainFailures 把领域 ContainerFailure 转成 proto ContainerFailure（透传全部诊断字段）。
+func mapDomainFailures(failures []*biz.ContainerFailure) []*project.ContainerFailure {
+	out := make([]*project.ContainerFailure, 0, len(failures))
+	for _, f := range failures {
+		out = append(out, &project.ContainerFailure{
+			Kind:      f.Kind,
+			Workload:  f.Workload,
+			Pod:       f.Pod,
+			Container: f.Container,
+			Reason:    f.Reason,
+			Message:   f.Message,
+			Logs:      f.Logs,
+		})
+	}
+	return out
+}
+
 var _ deploy.DeployMsger = (*emptyMessager)(nil)
 
 // emptyMessager 实现 deploy.DeployMsger 的空操作版本：所有推送方法均 no-op，

--- a/internal/services/project_test.go
+++ b/internal/services/project_test.go
@@ -23,6 +23,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"helm.sh/helm/v3/pkg/storage/driver"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestNewProjectSvc(t *testing.T) {
@@ -1057,6 +1060,95 @@ func Test_projectSvc_AllContainers_PermissionDenied(t *testing.T) {
 	mocks.projectRepo.EXPECT().Show(gomock.Any(), 1).Return(&biz.Project{NamespaceID: 1}, nil)
 	mocks.nsRepo.EXPECT().Show(gomock.Any(), 1).Return(&biz.Namespace{Private: true}, nil)
 	_, err := svc.AllContainers(newOtherUserCtx(), &project.AllContainersRequest{Id: 1})
+	assert.ErrorIs(t, err, errs.ErrorPermissionDenied)
+}
+
+// Test_projectSvc_CheckApplyStatus 覆盖 CheckApplyStatus 成功路径：无工作负载 → UNKNOWN，
+// 容器/失败明细空，且响应前做项目级访问控制。
+func Test_projectSvc_CheckApplyStatus(t *testing.T) {
+	svc, mocks := newProjectSvcWithMocks(t)
+	// Show 被调用两次：一次 svc 层 access-check，一次 biz.CheckApplyStatus 内部取项目。
+	// 项目无 PodSelectors 时 buildStateContainers 提前返回；GetWorkloadsByManifest 返回空 → UNKNOWN。
+	mocks.projectRepo.EXPECT().Show(gomock.Any(), 1).Return(&biz.Project{NamespaceID: 1}, nil).Times(2)
+	mocks.nsRepo.EXPECT().Show(gomock.Any(), 1).Return(&biz.Namespace{}, nil)
+	mocks.k8sRepo.EXPECT().GetWorkloadsByManifest(gomock.Any()).Return(nil, nil, nil)
+
+	resp, err := svc.CheckApplyStatus(newAdminUserCtx(), &project.CheckApplyStatusRequest{Id: 1})
+	assert.NoError(t, err)
+	assert.Equal(t, types.Deploy_StatusUnknown, resp.GetStatus())
+	assert.Contains(t, resp.GetReason(), "未发现")
+	assert.Empty(t, resp.GetContainers())
+	assert.Empty(t, resp.GetFailures())
+}
+
+func Test_projectSvc_CheckApplyStatus_BizError(t *testing.T) {
+	svc, mocks := newProjectSvcWithMocks(t)
+	// access-check 通过，biz 内部 Show 失败 → 整体报错。
+	mocks.projectRepo.EXPECT().Show(gomock.Any(), 1).Return(&biz.Project{NamespaceID: 1}, nil).Times(1)
+	mocks.projectRepo.EXPECT().Show(gomock.Any(), 1).Return(nil, errors.New("boom"))
+	mocks.nsRepo.EXPECT().Show(gomock.Any(), 1).Return(&biz.Namespace{}, nil)
+
+	resp, err := svc.CheckApplyStatus(newAdminUserCtx(), &project.CheckApplyStatusRequest{Id: 1})
+	assert.Nil(t, resp)
+	assert.ErrorContains(t, err, "boom")
+}
+
+// Test_projectSvc_CheckApplyStatus_FailedWithFailures 覆盖 FAILED 判定 + failures 映射链路：
+// Deployment 最新版本 pod CrashLoopBackOff → svc 层把领域失败诊断映射成 proto 明细并附日志。
+func Test_projectSvc_CheckApplyStatus_FailedWithFailures(t *testing.T) {
+	svc, mocks := newProjectSvcWithMocks(t)
+	mocks.projectRepo.EXPECT().Show(gomock.Any(), 1).Return(&biz.Project{
+		NamespaceID: 1,
+		Namespace:   &biz.Namespace{Name: "ns"},
+		Manifest:    []string{"deploy"},
+	}, nil).Times(2)
+	mocks.nsRepo.EXPECT().Show(gomock.Any(), 1).Return(&biz.Namespace{}, nil)
+
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "ns", Generation: 2, UID: "dep-uid"},
+		Spec:       appsv1.DeploymentSpec{Replicas: lo.ToPtr(int32(1))},
+		Status:     appsv1.DeploymentStatus{ObservedGeneration: 2, UpdatedReplicas: 1, AvailableReplicas: 0},
+	}
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "rs-new", Namespace: "ns", UID: "rs-uid",
+			Annotations:     map[string]string{"deployment.kubernetes.io/revision": "2"},
+			OwnerReferences: []metav1.OwnerReference{{Kind: "Deployment", UID: "dep-uid"}},
+		},
+	}
+	failPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-fail", Namespace: "ns", OwnerReferences: []metav1.OwnerReference{{Kind: "ReplicaSet", UID: "rs-uid"}}},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "web"}}},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+			Name:  "web",
+			State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
+		}}},
+	}
+
+	mocks.k8sRepo.EXPECT().GetWorkloadsByManifest(gomock.Any()).Return([]*appsv1.Deployment{dep}, nil, nil)
+	mocks.k8sRepo.EXPECT().ListReplicaSets("ns").Return([]*appsv1.ReplicaSet{rs}, nil)
+	mocks.k8sRepo.EXPECT().GetDeployment("ns", "web").Return(dep, nil)
+	mocks.k8sRepo.EXPECT().ListPodsBySelectors(gomock.Any(), gomock.Any()).Return([]*corev1.Pod{failPod}, nil)
+	mocks.k8sRepo.EXPECT().GetPodLogs(gomock.Any(), "ns", "pod-fail", gomock.Any()).Return("crash trace", nil)
+
+	resp, err := svc.CheckApplyStatus(newAdminUserCtx(), &project.CheckApplyStatusRequest{Id: 1})
+	assert.NoError(t, err)
+	assert.Equal(t, types.Deploy_StatusFailed, resp.GetStatus())
+	assert.Contains(t, resp.GetReason(), "CrashLoopBackOff")
+	if assert.Len(t, resp.GetFailures(), 1) {
+		assert.Equal(t, "Deployment", resp.GetFailures()[0].GetKind())
+		assert.Equal(t, "web", resp.GetFailures()[0].GetWorkload())
+		assert.Equal(t, "pod-fail", resp.GetFailures()[0].GetPod())
+		assert.Equal(t, "CrashLoopBackOff", resp.GetFailures()[0].GetReason())
+		assert.Equal(t, "crash trace", resp.GetFailures()[0].GetLogs())
+	}
+}
+
+func Test_projectSvc_CheckApplyStatus_PermissionDenied(t *testing.T) {
+	svc, mocks := newProjectSvcWithMocks(t)
+	mocks.projectRepo.EXPECT().Show(gomock.Any(), 1).Return(&biz.Project{NamespaceID: 1}, nil)
+	mocks.nsRepo.EXPECT().Show(gomock.Any(), 1).Return(&biz.Namespace{Private: true}, nil)
+	_, err := svc.CheckApplyStatus(newOtherUserCtx(), &project.CheckApplyStatusRequest{Id: 1})
 	assert.ErrorIs(t, err, errs.ErrorPermissionDenied)
 }
 


### PR DESCRIPTION
非原子 WebApply 无法确认新版本是否成功，新增 CheckApplyStatus RPC：
解析项目 manifest 中 Deployment/StatefulSet/DaemonSet 三类工作负载， 读取实时状态与新版本 pod 容器状态聚合判定——新版本全部就绪才
StatusDeployed，否则 Deploying；失败时返回失败容器明细 + 日志尾部
（CrashLoopBackOff 取上一次崩溃日志）。旧版本 pod 异常不影响判定。

同步修复 StateContainer is_old 误判：StatefulSet 按 controller-revision-hash 与 status.updateRevision 比对，DaemonSet 按最新 revision 分组识别旧副本。