### PR TITLE
feat: 错误/日志消息补充识别性上下文，提升排障可定位性

### DIFF
--- a/internal/biz/apply_status.go
+++ b/internal/biz/apply_status.go
@@ -186,10 +186,16 @@ func judgeDeploymentRollout(dep *appsv1.Deployment, rss []*appsv1.ReplicaSet, po
 	if dep.Status.UpdatedReplicas == 0 {
 		return types.Deploy_StatusDeploying, "新版本 pod 尚未创建", nil
 	}
-	if fails := collectPodFailures(deploymentNewPods(dep, rss, pods)); len(fails) > 0 {
+	newPods := deploymentNewPods(dep, rss, pods)
+	if fails := collectPodFailures(newPods); len(fails) > 0 {
 		return types.Deploy_StatusFailed, formatReason(fails), fails
 	}
 	if dep.Status.UpdatedReplicas == desired && dep.Status.AvailableReplicas == desired {
+		// 滚动窗口收尾：maxUnavailable=0 时旧 pod 要等新 pod Ready 才缩容，AvailableReplicas
+		// 会被旧 pod 撑满，计数满足但新 pod 未必就绪，必须核验新版本 pod 全部 Ready 才判成功。
+		if ready := podReadyCount(newPods); len(newPods) == int(desired) && ready != int(desired) {
+			return types.Deploy_StatusDeploying, fmt.Sprintf("滚动进行中 %d/%d 就绪", ready, desired), nil
+		}
 		return types.Deploy_StatusDeployed, "", nil
 	}
 	return types.Deploy_StatusDeploying, fmt.Sprintf("滚动进行中 %d/%d 就绪", dep.Status.AvailableReplicas, desired), nil
@@ -210,10 +216,15 @@ func judgeStatefulSetRollout(sts *appsv1.StatefulSet, pods []*corev1.Pod) (types
 	if sts.Status.UpdatedReplicas == 0 {
 		return types.Deploy_StatusDeploying, "新版本 pod 尚未创建", nil
 	}
-	if fails := collectPodFailures(statefulSetNewPods(sts, pods)); len(fails) > 0 {
+	newPods := statefulSetNewPods(sts, pods)
+	if fails := collectPodFailures(newPods); len(fails) > 0 {
 		return types.Deploy_StatusFailed, formatReason(fails), fails
 	}
 	if sts.Status.UpdatedReplicas == desired && sts.Status.AvailableReplicas == desired {
+		// 与 Deployment 同一滚动窗口收尾逻辑：核验最新版本 pod 全部 Ready，避免计数满足但新 pod 未就绪误报成功。
+		if ready := podReadyCount(newPods); len(newPods) == int(desired) && ready != int(desired) {
+			return types.Deploy_StatusDeploying, fmt.Sprintf("滚动进行中 %d/%d 就绪", ready, desired), nil
+		}
 		return types.Deploy_StatusDeployed, "", nil
 	}
 	return types.Deploy_StatusDeploying, fmt.Sprintf("滚动进行中 %d/%d 就绪", sts.Status.AvailableReplicas, desired), nil
@@ -231,10 +242,15 @@ func judgeDaemonSetRollout(ds *appsv1.DaemonSet, pods []*corev1.Pod) (types.Depl
 	if ds.Status.UpdatedNumberScheduled == 0 {
 		return types.Deploy_StatusDeploying, "新版本 pod 尚未创建", nil
 	}
-	if fails := collectPodFailures(daemonSetNewPods(pods)); len(fails) > 0 {
+	newPods := daemonSetNewPods(pods)
+	if fails := collectPodFailures(newPods); len(fails) > 0 {
 		return types.Deploy_StatusFailed, formatReason(fails), fails
 	}
 	if ds.Status.UpdatedNumberScheduled == desired && ds.Status.NumberAvailable == desired {
+		// 与 Deployment 同一滚动窗口收尾逻辑：核验最新版本 pod 全部 Ready，避免计数满足但新 pod 未就绪误报成功。
+		if ready := podReadyCount(newPods); len(newPods) == int(desired) && ready != int(desired) {
+			return types.Deploy_StatusDeploying, fmt.Sprintf("滚动进行中 %d/%d 就绪", ready, desired), nil
+		}
 		return types.Deploy_StatusDeployed, "", nil
 	}
 	return types.Deploy_StatusDeploying, fmt.Sprintf("滚动进行中 %d/%d 就绪", ds.Status.NumberAvailable, desired), nil
@@ -361,6 +377,30 @@ func collectPodFailures(pods []*corev1.Pod) []failedContainerRef {
 		}
 	}
 	return refs
+}
+
+// podReadyCount 统计全部容器已 Ready 的 pod 数；新 pod 尚未就绪（无容器状态/容器未 Ready）均不计入。
+func podReadyCount(pods []*corev1.Pod) int {
+	ready := 0
+	for _, p := range pods {
+		if podAllContainersReady(p) {
+			ready++
+		}
+	}
+	return ready
+}
+
+// podAllContainersReady 判断 pod 的所有容器是否都已 Ready（容器状态为空视为未就绪）。
+func podAllContainersReady(pod *corev1.Pod) bool {
+	if len(pod.Status.ContainerStatuses) == 0 {
+		return false
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		if !cs.Ready {
+			return false
+		}
+	}
+	return true
 }
 
 // formatReason 把失败容器汇总为人类可读原因（逐条列出，分号分隔）。

--- a/internal/biz/apply_status_test.go
+++ b/internal/biz/apply_status_test.go
@@ -141,6 +141,41 @@ func TestJudgeDeploymentRollout_Deployed(t *testing.T) {
 	assert.Empty(t, fails)
 }
 
+// TestJudgeDeploymentRollout_NewPodNotReady 覆盖用户上报场景：滚动窗口期新 pod 已创建但
+// 未就绪（ContainerCreating），旧 pod 仍在运行撑起 AvailableReplicas——Deployment 计数
+// 满足 updated=available=desired 但新 pod 未 Ready，不得误判 Deployed。
+func TestJudgeDeploymentRollout_NewPodNotReady(t *testing.T) {
+	dep := newDepForTest(1, 1, 1) // UpdatedReplicas=1, AvailableReplicas=1, desired=1
+	dep.UID = "dep"
+	rss := []*appsv1.ReplicaSet{
+		newRSForTest("rs-old", "1", "dep"),
+		newRSForTest("rs-new", "2", "dep"),
+	}
+	newPod := rsPodForTest("pod-new", "rs-new", "")
+	newPod.Status.ContainerStatuses[0].Ready = false // 新 pod 容器未就绪
+	oldPod := rsPodForTest("pod-old", "rs-old", "")  // 旧 pod 仍 Ready
+	st, reason, fails := judgeDeploymentRollout(dep, rss, []*corev1.Pod{newPod, oldPod})
+	assert.Equal(t, types.Deploy_StatusDeploying, st)
+	assert.Contains(t, reason, "0/1")
+	assert.Empty(t, fails)
+}
+
+// TestJudgeDeploymentRollout_NewPodReady 覆盖滚动窗口收尾：新 pod 已 Ready 才判 Deployed。
+func TestJudgeDeploymentRollout_NewPodReady(t *testing.T) {
+	dep := newDepForTest(1, 1, 1)
+	dep.UID = "dep"
+	rss := []*appsv1.ReplicaSet{
+		newRSForTest("rs-old", "1", "dep"),
+		newRSForTest("rs-new", "2", "dep"),
+	}
+	newPod := rsPodForTest("pod-new", "rs-new", "") // Ready=true
+	oldPod := rsPodForTest("pod-old", "rs-old", "")
+	st, reason, fails := judgeDeploymentRollout(dep, rss, []*corev1.Pod{newPod, oldPod})
+	assert.Equal(t, types.Deploy_StatusDeployed, st)
+	assert.Empty(t, reason)
+	assert.Empty(t, fails)
+}
+
 // ---------- judgeStatefulSetRollout ----------
 
 func TestJudgeStatefulSetRollout_DesiredZero(t *testing.T) {
@@ -202,6 +237,21 @@ func TestJudgeStatefulSetRollout_Deployed(t *testing.T) {
 	assert.Empty(t, fails)
 }
 
+// TestJudgeStatefulSetRollout_NewPodNotReady 覆盖 STS 滚动窗口期最新版本 pod 未 Ready：
+// 计数满足但新 pod 未就绪，不得误判 Deployed。
+func TestJudgeStatefulSetRollout_NewPodNotReady(t *testing.T) {
+	sts := newStsForTest(1, 1, 1, "rev2")
+	newPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "sts-new", Namespace: "ns", Labels: map[string]string{appsv1.ControllerRevisionHashLabelKey: "rev2"}},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "web"}}},
+		Status:     corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{Name: "web", Ready: false}}},
+	}
+	st, reason, fails := judgeStatefulSetRollout(sts, []*corev1.Pod{newPod})
+	assert.Equal(t, types.Deploy_StatusDeploying, st)
+	assert.Contains(t, reason, "0/1")
+	assert.Empty(t, fails)
+}
+
 // ---------- judgeDaemonSetRollout ----------
 
 func TestJudgeDaemonSetRollout_DesiredZero(t *testing.T) {
@@ -260,6 +310,21 @@ func TestJudgeDaemonSetRollout_Deployed(t *testing.T) {
 	st, reason, fails := judgeDaemonSetRollout(newDsForTest(3, 3, 3), nil)
 	assert.Equal(t, types.Deploy_StatusDeployed, st)
 	assert.Empty(t, reason)
+	assert.Empty(t, fails)
+}
+
+// TestJudgeDaemonSetRollout_NewPodNotReady 覆盖 DS 滚动窗口期最新 hash 组 pod 未 Ready：
+// 计数满足但新 pod 未就绪，不得误判 Deployed。
+func TestJudgeDaemonSetRollout_NewPodNotReady(t *testing.T) {
+	ds := newDsForTest(1, 1, 1)
+	newPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "ds-new", Namespace: "ns", CreationTimestamp: metav1.Time{Time: time.Now()}, Labels: map[string]string{appsv1.ControllerRevisionHashLabelKey: "hash-new"}},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "web"}}},
+		Status:     corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{Name: "web", Ready: false}}},
+	}
+	st, reason, fails := judgeDaemonSetRollout(ds, []*corev1.Pod{newPod})
+	assert.Equal(t, types.Deploy_StatusDeploying, st)
+	assert.Contains(t, reason, "0/1")
 	assert.Empty(t, fails)
 }
 
@@ -328,6 +393,28 @@ func TestCollectPodFailures_TransientIgnored(t *testing.T) {
 		},
 	}
 	assert.Empty(t, collectPodFailures(pods))
+}
+
+// TestPodAllContainersReady 覆盖无容器状态/任一容器未就绪/全部就绪三条分支。
+func TestPodAllContainersReady(t *testing.T) {
+	assert.False(t, podAllContainersReady(&corev1.Pod{})) // 无容器状态 → 未就绪
+	assert.False(t, podAllContainersReady(&corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+		{Name: "web", Ready: false}, {Name: "sidecar", Ready: true},
+	}}})) // 任一容器未就绪 → 未就绪
+	assert.True(t, podAllContainersReady(&corev1.Pod{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{
+		{Name: "web", Ready: true},
+	}}})) // 全部就绪
+}
+
+// TestPodReadyCount 覆盖空列表与混合就绪态的计数。
+func TestPodReadyCount(t *testing.T) {
+	pods := []*corev1.Pod{
+		{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{Name: "web", Ready: true}}}},
+		{Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{Name: "web", Ready: false}}}},
+		{},
+	}
+	assert.Equal(t, 1, podReadyCount(pods))
+	assert.Equal(t, 0, podReadyCount(nil))
 }
 
 // ---------- 新版本 pod 定位辅助 ----------
@@ -708,6 +795,32 @@ func TestCheckApplyStatus_FailedChain(t *testing.T) {
 		assert.Equal(t, "CrashLoopBackOff", got.Failures[0].Reason)
 		assert.Equal(t, "crash trace", got.Failures[0].Logs)
 	}
+}
+
+// TestCheckApplyStatus_TransitionWindowNewPodNotReady 复现用户上报场景：滚动窗口期
+// Deployment 计数 updated=available=desired 已满足，但新版本 web pod 未 Ready、旧 pod
+// 仍 Ready（撑起 AvailableReplicas），整体必须判 Deploying 而非 Deployed。
+func TestCheckApplyStatus_TransitionWindowNewPodNotReady(t *testing.T) {
+	dep := newDepForTest(1, 1, 1)
+	dep.Name = "web"
+	dep.UID = "dep"
+	oldRS := newRSForTest("rs-old", "1", "dep")
+	newRS := newRSForTest("rs-new", "2", "dep")
+	newPod := rsPodForTest("pod-new", "rs-new", "")
+	newPod.Status.ContainerStatuses[0].Ready = false
+	oldPod := rsPodForTest("pod-old", "rs-old", "")
+	k := &fakeStatusK8sRepo{
+		depWorkloads: []*appsv1.Deployment{dep},
+		deployments:  map[string]*appsv1.Deployment{"web": dep},
+		replicaSets:  []*appsv1.ReplicaSet{oldRS, newRS},
+		pods:         []*corev1.Pod{newPod, oldPod},
+	}
+	proj := &Project{Namespace: &Namespace{Name: "ns"}, PodSelectors: []string{"app=web"}, Manifest: []string{"web deploy"}}
+	b := newStatusProjectBiz(&fakeStatusProjectRepo{project: proj}, k)
+	got, err := b.CheckApplyStatus(context.TODO(), 1)
+	assert.NoError(t, err)
+	assert.Equal(t, types.Deploy_StatusDeploying, got.Status)
+	assert.Contains(t, got.Reason, "web")
 }
 
 // ---------- judgeWorkloads 聚合 ----------

--- a/internal/biz/container.go
+++ b/internal/biz/container.go
@@ -418,7 +418,7 @@ func (cb *containerBiz) resolveLog(ctx context.Context, input *LogInput) (*v1.Po
 		return nil, err
 	}
 	if podInfo == nil || (!input.ShowEvents && podInfo.Status.Phase == v1.PodPending) {
-		return nil, errs.NotFound("未找到日志")
+		return nil, errs.NotFound(fmt.Sprintf("未找到日志: %s/%s", input.Namespace, input.Pod))
 	}
 	return podInfo, nil
 }

--- a/internal/biz/git.go
+++ b/internal/biz/git.go
@@ -93,23 +93,24 @@ func (g *gitBiz) EnsureBranchAndCommit(ctx context.Context, show *Repo, inBranch
 	if show == nil {
 		return "", "", nil, errs.WrapInvalidArgument(errors.New("repo 不能为空"), "ensure branch and commit")
 	}
+	projectID := int(show.GitProjectID)
 	branch = inBranch
 	commit = inCommit
 	if branch == "" {
 		branch = show.DefaultBranch
-		msgs = append(msgs, fmt.Sprintf("未传入分支，使用默认分支 %s", branch))
+		msgs = append(msgs, fmt.Sprintf("项目 %d 未传入分支，使用默认分支 %s", projectID, branch))
 	}
 	if commit == "" {
-		commits, err := g.gitRepo.ListCommits(ctx, int(show.GitProjectID), branch)
+		commits, err := g.gitRepo.ListCommits(ctx, projectID, branch)
 		if err != nil {
 			return "", "", nil, err
 		}
 		if len(commits) < 1 {
-			return "", "", nil, errs.NotFound("没有可用的 commit")
+			return "", "", nil, errs.NotFound(fmt.Sprintf("项目 %d 分支 %s 没有可用的 commit", projectID, branch))
 		}
 		lastCommit := commits[0]
 		commit = lastCommit.ID
-		msgs = append(msgs, fmt.Sprintf("未传入commit，使用最新的commit [%s](%s)", lastCommit.Title, lastCommit.WebURL))
+		msgs = append(msgs, fmt.Sprintf("项目 %d 分支 %s 未传入commit，使用最新的commit [%s](%s)", projectID, branch, lastCommit.Title, lastCommit.WebURL))
 	}
 	return branch, commit, msgs, nil
 }

--- a/internal/biz/namespace.go
+++ b/internal/biz/namespace.go
@@ -12,6 +12,7 @@ package biz
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -134,7 +135,7 @@ func (n *namespaceBiz) Create(ctx context.Context, namespace, description, creat
 		// CreateDockerSecret 失败只可能是 k8s API 错误（RBAC/网络/配额），
 		// 属于真实基建问题——namespace 创建继续（降级），但必须 Error 级可见，
 		// 否则后续私有镜像 pull 失败会以"不透明的拉取失败"浮出，排障无抓手。
-		n.logger.ErrorCtx(ctx, err)
+		n.logger.ErrorCtx(ctx, fmt.Sprintf("创建 namespace %s 的 docker secret 失败", create.Name), err)
 	}
 
 	ns, err := n.nsRepo.Create(ctx, &CreateNamespaceInput{
@@ -182,7 +183,7 @@ func (n *namespaceBiz) Delete(ctx context.Context, ns *Namespace) ([]string, err
 			defer n.logger.HandlePanic("namespaceBiz.Delete")
 			n.logger.Debugf("delete release %s namespace %s", releaseName, namespace)
 			if err := n.helmerRepo.Uninstall(releaseName, namespace, n.logger.Debugf); err != nil {
-				n.logger.ErrorCtx(ctx, err)
+				n.logger.ErrorCtx(ctx, fmt.Sprintf("卸载 release %s 于 namespace %s 失败", releaseName, namespace), err)
 				return
 			}
 		}(project.Name, ns.Name)

--- a/internal/data/file.go
+++ b/internal/data/file.go
@@ -453,7 +453,7 @@ func (r *recorder) Close() error {
 			io.WriteString(upFile, fmt.Sprintf(startLine, r.width, r.height, r.startTime.Unix(), shell))
 		}()
 		if _, err := io.Copy(upFile, r.f); err != nil {
-			r.logger.Error(err)
+			r.logger.Errorf("recorder 写入 shell 回放文件失败 %s/%s/%s: %v", r.container.Namespace, r.container.Pod, r.container.Container, err)
 		}
 	}()
 

--- a/internal/data/k8s.go
+++ b/internal/data/k8s.go
@@ -117,7 +117,7 @@ func (repo *k8sRepo) CopyFromPod(ctx context.Context, input *biz.CopyFromPodInpu
 	})
 	isFile := strings.Trim(lsbf.String(), "\n") == "1"
 	if !isFile {
-		return nil, errs.WrapInvalidArgument(errors.New("下载内容必须是文件"), "k8s download file")
+		return nil, errs.WrapInvalidArgument(fmt.Errorf("下载内容必须是文件: %s %s", input.Pod, input.FilePath), "k8s download file")
 	}
 
 	pwdbf := &bytes.Buffer{}
@@ -136,7 +136,7 @@ func (repo *k8sRepo) CopyFromPod(ctx context.Context, input *biz.CopyFromPodInpu
 	base := strings.Trim(pwdbf.String(), "\n")
 
 	if !strings.HasPrefix(input.FilePath, base) {
-		return nil, errs.WrapInvalidArgument(errors.New("invalid file path"), "k8s download file")
+		return nil, errs.WrapInvalidArgument(fmt.Errorf("非法文件路径: %s %s", input.Pod, input.FilePath), "k8s download file")
 	}
 
 	// base 为容器内 pwd 绝对路径，FilePath 已在上方校验以 base 为前缀，二者同为绝对路径，
@@ -464,7 +464,7 @@ func (repo *k8sRepo) FindDefaultContainer(ctx context.Context, namespace string,
 		return co.Name, nil
 	}
 
-	return "", errs.NotFound("未找到容器")
+	return "", errs.NotFound(fmt.Sprintf("未找到容器: %s/%s", namespace, pod))
 }
 
 // GetPod 经 informer lister 读取 Pod（不实时访问 apiserver）。
@@ -747,7 +747,7 @@ func (repo *k8sRepo) ClusterInfo() *biz.ClusterInfo {
 	if err != nil {
 		// List 失败时 nodeList 为 nil，直接访问 .Items 会 panic，
 		// 记录错误后按空集群返回，避免集群信息接口直接崩溃。
-		repo.logger.Error(err)
+		repo.logger.Errorf("list nodes by selector %s: %v", selector.String(), err)
 		return &biz.ClusterInfo{}
 	}
 	nodes = append(nodes, nodeList.Items...)
@@ -796,7 +796,7 @@ func (repo *k8sRepo) ClusterInfo() *biz.ClusterInfo {
 	if err != nil {
 		// metrics List 失败时 list 为 nil，range list.Items 会 panic，
 		// 记录错误后用空列表继续（节点信息仍有效，仅用量统计为空）。
-		repo.logger.Error(err)
+		repo.logger.Errorf("list node metrics by selector %s: %v", selector.String(), err)
 		list = &v1beta1.NodeMetricsList{}
 	}
 

--- a/internal/data/k8s_test.go
+++ b/internal/data/k8s_test.go
@@ -1292,7 +1292,7 @@ func TestCopyFromPod(t *testing.T) {
 		UserName:  "test-user",
 	})
 	s, _ := status.FromError(err)
-	assert.Equal(t, "下载内容必须是文件", s.Message())
+	assert.Equal(t, "下载内容必须是文件: test-pod /test/file/path", s.Message())
 	assert.Equal(t, codes.InvalidArgument, s.Code())
 }
 
@@ -1568,7 +1568,7 @@ func TestFindDefaultContainer_NoContainers(t *testing.T) {
 	assert.Error(t, err)
 	// errs.NotFound 映射为 grpc NotFound：断言状态码与消息，而非 Error() 全串（带 grpc 前缀）。
 	assert.Equal(t, codes.NotFound, status.Code(err))
-	assert.Equal(t, "未找到容器", status.Convert(err).Message())
+	assert.Equal(t, "未找到容器: a/nocontainers", status.Convert(err).Message())
 }
 
 // TestListPodsBySelectors 覆盖按 selector 列 Pod：命中、跨 selector 去重、
@@ -1946,7 +1946,7 @@ func TestCopyFromPod_invalidPath(t *testing.T) {
 	})
 	s, _ := status.FromError(err)
 	assert.Equal(t, codes.InvalidArgument, s.Code())
-	assert.Equal(t, "invalid file path", s.Message())
+	assert.Equal(t, "非法文件路径: p /p", s.Message())
 }
 
 // TestCopyFromPod_fileCopyError 覆盖归档复制失败分支：err 非 nil 触发

--- a/internal/deploy/loader.go
+++ b/internal/deploy/loader.go
@@ -198,7 +198,7 @@ func (c *ChartFileLoader) Load(ctx *LoadContext) error {
 	ctx.Messager.To(20)
 
 	if !biz.IsRemoteLocalChartPath(ctx.Config.LocalChartPath) {
-		return errors.New("LocalChartPath 格式不正确")
+		return errors.New("LocalChartPath 格式不正确: " + ctx.Config.LocalChartPath)
 	}
 
 	// 下载 helm charts
@@ -225,7 +225,7 @@ func (c *ChartFileLoader) Load(ctx *LoadContext) error {
 		return errs.Wrap(err, "获取远程 charts 文件")
 	}
 	if len(files) < 1 {
-		return errors.New("charts 文件不存在")
+		return fmt.Errorf("charts 文件不存在: %s", ctx.Config.LocalChartPath)
 	}
 	tmpChartsDir, deleteDirFn, err = ctx.DownloadFiles(pid, branch, files)
 	if err != nil {

--- a/internal/deploy/loader_test.go
+++ b/internal/deploy/loader_test.go
@@ -284,7 +284,7 @@ func TestChartFileLoader_NoFilesError(t *testing.T) {
 		Config:    &mars.Config{LocalChartPath: "9999|master|dir"},
 		PluginMgr: pl,
 	}
-	assert.Equal(t, "charts 文件不存在", (&ChartFileLoader{}).Load(ctx).Error())
+	assert.Equal(t, "charts 文件不存在: 9999|master|dir", (&ChartFileLoader{}).Load(ctx).Error())
 }
 
 func TestMergeValuesLoader_NewYAMLError(t *testing.T) {

--- a/internal/deploy/runner_test.go
+++ b/internal/deploy/runner_test.go
@@ -1424,7 +1424,7 @@ func TestChartFileLoader_LoadWithChartMissing(t *testing.T) {
 
 	ctx.Config.LocalChartPath = "xxx"
 	err = l.Load(ctx)
-	assert.Equal(t, "LocalChartPath 格式不正确", err.Error())
+	assert.Equal(t, "LocalChartPath 格式不正确: xxx", err.Error())
 }
 
 func TestLoadContext_WriteConfigYamlToTmpFile(t *testing.T) {

--- a/internal/services/container_test.go
+++ b/internal/services/container_test.go
@@ -482,7 +482,7 @@ func TestContainerSvc_StreamContainerLog_PodPending1(t *testing.T) {
 		Pod:       "b",
 	}, s)
 
-	assert.Equal(t, "未找到日志", status.Convert(err).Message())
+	assert.Equal(t, "未找到日志: a/b", status.Convert(err).Message())
 }
 
 func TestContainerSvc_StreamContainerLog_PodPending_ShowEvents(t *testing.T) {

--- a/internal/services/file_handler.go
+++ b/internal/services/file_handler.go
@@ -94,7 +94,7 @@ func (f *fileHandler) httpDownload(w http.ResponseWriter, r *http.Request, pathP
 	ctx := r.Context()
 	fil, err := f.fileBiz.GetByID(ctx, id)
 	if err != nil {
-		f.logger.Error("Error getting file: ", err)
+		f.logger.ErrorCtx(ctx, fmt.Sprintf("Error getting file id %d: ", id), err)
 		toHttpError(w, err)
 		return
 	}

--- a/internal/services/namespace.go
+++ b/internal/services/namespace.go
@@ -143,7 +143,7 @@ func (n *namespaceSvc) Create(ctx context.Context, request *namespace.CreateRequ
 		}
 		// exists 且非 IgnoreIfExists：拒绝并返回 AlreadyExists——状态码由 biz 工厂提供，
 		// transport 不再散落 status.Error 构造（协议映射收口 biz）。
-		return nil, errs.AlreadyExists("名称空间已存在")
+		return nil, errs.AlreadyExists(fmt.Sprintf("名称空间 %s 已存在", request.Namespace))
 	}
 
 	n.eventBiz.AuditLogWithRequest(

--- a/internal/services/websocket/conn.go
+++ b/internal/services/websocket/conn.go
@@ -7,7 +7,7 @@ package websocket
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"io"
 	"sync"
 	"time"
@@ -231,5 +231,5 @@ func (c *wsConn) RunCancelDeployTask(id string) error {
 		c.taskManager.Stop(id)
 		return nil
 	}
-	return errors.New("task not found")
+	return fmt.Errorf("部署任务 %s 不存在", id)
 }

--- a/internal/services/websocket/conn_test.go
+++ b/internal/services/websocket/conn_test.go
@@ -44,7 +44,7 @@ func TestWsConn_AddTask_RunTask_RemoveTask(t *testing.T) {
 	conn.RemoveCancelDeployTask("task1")
 	err = conn.RunCancelDeployTask("task1")
 	assert.NotNil(t, err)
-	assert.Equal(t, "task not found", err.Error())
+	assert.Equal(t, "部署任务 task1 不存在", err.Error())
 }
 
 func TestWebsocketManager_newWsConn(t *testing.T) {


### PR DESCRIPTION
EnsureBranchAndCommit 的提示与 NotFound 带上项目 id/分支；namespace 已存在、 未找到容器/日志、CopyFromPod 校验、LocalChartPath/charts 缺失、部署任务等 错误消息补上 ns/pod/path/id 等关键标识；异步/降级路径日志补 selector、
namespace、release 等上下文。测试断言同步更新。